### PR TITLE
0.14.0 — Added files property to package.json to explicitly state which files should be published.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.14.0
+------------------------------
+*September 26, 2017*
+
+### Changed
+- Added `"files"` property to `package.json` to explicitly state which files should be published.
+
+
 v0.13.0
 ------------------------------
 *September 26, 2017*

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "dist/js/index.js",
+  "files": [
+    "./dist",
+    "./src/img",
+    "./src/scss"
+  ],
   "homepage": "https://github.com/justeat/f-footer",
   "contributors": [
     "Github contributors <https://github.com/justeat/f-footer/graphs/contributors>"


### PR DESCRIPTION
### Changed
- Added `"files"` property to `package.json` to explicitly state which files should be published.