### PR TITLE
CPD-11454: Fixed icon chevron path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.28.0
+------------------------------
+*June 05, 2018*
+
+### Fixed
+- `chevronIconUrl` to be `miscIconPaths.chevronIconUrl` so it matches the footer model.
+
+
 v0.27.0
 ------------------------------
 *June 05, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/footer/partials/site-navigation-links.hbs
+++ b/src/templates/footer/partials/site-navigation-links.hbs
@@ -1,7 +1,7 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-1">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-1" data-toggle-class="is-collapsed">
         {{ i18n "customerService" }}
-        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ chevronIconUrl }}" alt="" />
+        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
     <ul class="c-footer-list">
@@ -14,7 +14,7 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-2">
     <h2 data-test-id="cuisine-footer-heading" class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-2" data-toggle-class="is-collapsed">
         {{ i18n "cuisines" }}
-        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ chevronIconUrl }}" alt="" />
+        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
     <ul class="c-footer-list">
@@ -27,7 +27,7 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-3">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-3" data-toggle-class="is-collapsed">
         {{ i18n "towns" }}
-        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ chevronIconUrl }}" alt="" />
+        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
     <ul class="c-footer-list">
@@ -40,7 +40,7 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-4">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-4" data-toggle-class="is-collapsed">
         {{ i18n "aboutUs" }}
-        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ chevronIconUrl }}" alt="" />
+        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
     <ul class="c-footer-list">


### PR DESCRIPTION
The path to the `chevronIconUrl` should point to the correct parent object from footer model provider. 

`miscIconPaths.chevronIconUrl`