### PR TITLE
v0.31.0 - Change Switzerland to HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.31.0
+------------------------------
+*July 24, 2018*
+
+### Fixed
+- Links to `www.eat.ch` now use `https` instead of `http`
+
 v0.30.0
 ------------------------------
 *July 5, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -248,7 +248,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Schweiz",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             },
             {
                 "name": "spain",
@@ -525,7 +525,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Suiza",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             }
         ]
     },
@@ -785,7 +785,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             }
         ]
     },
@@ -1038,7 +1038,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             }
         ]
     },
@@ -1248,7 +1248,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             }
         ]
     },
@@ -1493,7 +1493,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Svizzera",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             }
         ]
     },
@@ -1732,7 +1732,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             },
             {
                 "name": "uk",
@@ -1969,7 +1969,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Sveits",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             }
         ]
     },
@@ -2238,7 +2238,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             },
             {
                 "name": "uk",
@@ -2515,7 +2515,7 @@
                 "name": "switzerland",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Suisse",
-                "siteUrl": "http://www.eat.ch"
+                "siteUrl": "https://www.eat.ch"
             }
         ]
     }


### PR DESCRIPTION
Link to HTTPS for `www.eat.ch` instead of HTTP.
