### PR TITLE
v0.32.0 - Do not call getBreakpoints() until needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.32.0
+------------------------------
+*July 24, 2018*
+
+### Fixed
+- Fix `TypeError` caused by `getBreakpoints()` being called before the document is ready
+
 v0.31.0
 ------------------------------
 *July 24, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,9 +4,14 @@ import { getBreakpoints } from '@justeat/fozzie';
 import debounce from 'lodash.debounce';
 
 let footerPanels;
-const breakpoints = getBreakpoints();
+let breakpoints = null;
 
 const tabindexResize = () => {
+
+    if (breakpoints === null) {
+        breakpoints = getBreakpoints();
+    }
+
     if (window.matchMedia(`(min-width: ${breakpoints.mid})`).matches) {
         footerPanels.forEach(panel => {
             panel.removeAttribute('tabindex');


### PR DESCRIPTION
Do not call the `getBreakpoints()` function until it is first needed, as otherwise the document may not yet have a `<body>` element and a `TypeError` will be thrown by it.

Internally I have a failing Selenium test with this in the logs:

```js
Uncaught TypeError: Cannot read property 'appendChild' of null
```

Tracing through the compiled JS of that application, this appears to be caused by the following call chain as `f-footer` is evaluated by the browser:
  1. [`breakpointHelper.js:14`](https://github.com/justeat/fozzie/blob/a41a929ccc4ac192af2880304861207dd038f18d/src/js/modules/breakpointHelper.js#L14)
  1. [`index.js:7`](https://github.com/justeat/f-footer/blob/22795932b83bb6e846a4867b5877727b07e63e0e/src/js/index.js#L7)

This PR changes `index.js` to call `getBreakpoints()` lazily in `tabindexResize()` so that it is loaded on the first call to [`resizeInit()`](https://github.com/justeat/f-footer/blob/22795932b83bb6e846a4867b5877727b07e63e0e/src/js/index.js#L30) in [`ready()`](https://github.com/justeat/f-footer/blob/22795932b83bb6e846a4867b5877727b07e63e0e/src/js/index.js#L35) when the body element should be available.
