### PR TITLE
v1.3.0 - fix direction of chevrons in `c-footer-panel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.3.0
+------------------------------
+*September 27, 2018*
+
+### Fixed
+- Fixed direction of `c-footer-panel` chevon
+
+
 v1.2.0
 ------------------------------
 *September 27, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -100,9 +100,13 @@ $footer-socialIconColor : $grey--dark !default;
             border-bottom: 1px solid $footer-borderColor;
             cursor: pointer;
 
+            .c-footer-chevron {
+                transform: rotate(180deg);
+            }
+
             &.is-collapsed {
                 .c-footer-chevron {
-                    transform: rotate(180deg);
+                    transform: rotate(0);
                 }
 
                 .c-footer-list {


### PR DESCRIPTION
 - fix direction of chevrons in `c-footer-panel`
The direction of the closed / open chevron was backwards - assuming from an icon update(?) maybe.

Before:
<img width="304" alt="screen shot 2018-09-27 at 15 45 17" src="https://user-images.githubusercontent.com/5295718/46154658-8ac21880-c26d-11e8-8d7f-46b8c24b0c8d.png">

After:
<img width="291" alt="screen shot 2018-09-27 at 15 44 06" src="https://user-images.githubusercontent.com/5295718/46154662-8c8bdc00-c26d-11e8-8154-b31680fef82f.png">

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [x] Chrome
- [x] Safari
- [x] IE 11
- [x] Firefox
- [x] Mobile 