### PR TITLE
v1.3.1 Fixed currentCountryFlagIconUrl to match GB flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.3.1
+------------------------------
+*October 5, 2018*
+
+### Fixed
+- Fixed "currentCountryFlagIconUrl" to match GB flag
 
 v1.3.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer-docs-data.json
+++ b/src/templates/resources/footer-docs-data.json
@@ -3,7 +3,7 @@
     "miscIconPaths": {
         "chevronIconUrl": "/assets/img/icons/arrows/chevron.svg",
         "crossIconUrl": "/assets/img/icons/operators/cross.svg",
-        "currentCountryFlagIconUrl": "/assets/img/icons/flags/flag.dk.svg"
+        "currentCountryFlagIconUrl": "/assets/img/icons/flags/flag.gb.svg"
     },
     "socialIconPaths": {
         "facebookIconUrl": "/assets/img/icons/social/icon-facebook.svg",


### PR DESCRIPTION
Fixed currentCountryFlagIconUrl to match GB flag

Before:
<img width="348" alt="screen shot 2018-10-05 at 09 12 04" src="https://user-images.githubusercontent.com/19548183/46523834-cd43b080-c87e-11e8-8b03-754db0192620.png">


After:
<img width="334" alt="screen shot 2018-10-05 at 09 11 43" src="https://user-images.githubusercontent.com/19548183/46523827-c74dcf80-c87e-11e8-8fab-c8f1e38e877a.png">
