### PR TITLE
v1.6.0 - Add missing Spanish text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ v1.6.0
 ------------------------------
 *October 27, 2018*
 
+### Changed
+- Updated an `http` link to use `https`.
+
 ### Fixed
 - Adding missing Spanish translations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.6.0
+------------------------------
+*October 27, 2018*
+
+### Fixed
+- Adding missing Spanish translations.
+
 
 v1.5.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1521,7 +1521,7 @@
                 "text": "Cookie Policy"
             },
             {
-                "url": "http://www.justeatshop.ie/gift-vouchers",
+                "url": "https://www.justeatshop.ie/gift-vouchers",
                 "text": "Just Eat Gift Cards"
             },
             {

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -252,8 +252,8 @@
         ]
     },
     "es-ES": {
-        "improveOurWebsite": "Help us improve our website",
-        "sendFeedback": "Send feedback",
+        "improveOurWebsite": "Ayúdanos a mejorar la web",
+        "sendFeedback": "Enviar opinión",
         "vatInfo": "",
         "customerService": "Atención al cliente",
         "changeCurrentCountry": "Estás en Just Eat España. Haz clic aquí para cambiar país.",


### PR DESCRIPTION
  1. Add missing Spanish translations for the feedback text (taken from Spanish homepage).
  1. Update the URL for the Just Eat Shop in Ireland to use HTTPS instead of HTTP.
