### PR TITLE
v1.8.0 Footer icons optimization via svg sprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.8.0
+------------------------------
+*November 6, 2018*
+
+### Added
+- Svg sprite handlebars partial
+
+### Changed
+- Flags, misc and social icons are calling from svg sprite instead of regular img tag.
+
+This version needs WebBoilerplate >= v1.0.41
+
+
 v1.7.0
 ------------------------------
 *October 29, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/footer/partials/apps-and-social-links.hbs
+++ b/src/templates/footer/partials/apps-and-social-links.hbs
@@ -5,6 +5,7 @@
         {{#each (i18n "appStoreIcons") as | appStoreIcon |}}
             <li class="c-footer-list-item">
                 <a href="{{ appStoreIcon.url }}" target="_blank">
+                    {{!-- We can't use svg sprite here because of gradient effect which doesn't work with sprites in Chrome and Safari --}}
                     <img class="c-footer-icon c-icon--{{ appStoreIcon.key }}" src="{{  lookup ../appIconPaths appStoreIcon.iconSrc }}" alt="{{ appStoreIcon.altText }}" />
                 </a>
             </li>
@@ -19,7 +20,7 @@
         {{#each (i18n "socialIcons") as | socialIcon |}}
             <li class="c-footer-list-item">
                 <a href="{{ socialIcon.url }}" target="_blank">
-                    <img class="c-footer-icon c-footer-icon--social" src="{{ lookup ../socialIconPaths socialIcon.iconSrc }}" alt="{{ socialIcon.altText }}" />
+                    {{> je-svg-sprite cssClass="c-footer-icon c-footer-icon--social" spriteUrl=(concat (lookup ../svgSpriteModel 'iconsSpritePath') '#icons-social-icon-' socialIcon.key) }}
                 </a>
             </li>
         {{/each}}

--- a/src/templates/footer/partials/country-selector.hbs
+++ b/src/templates/footer/partials/country-selector.hbs
@@ -1,25 +1,25 @@
 <div class="c-countrySelector">
     <button type="button" class="o-btn o-btnLink c-countrySelector-link c-countrySelector-link--selected" data-toggle-target="countrySelector-list" aria-label="{{ i18n "changeCurrentCountry" }}">
-        <img class="c-icon--flag--small" src="{{ miscIconPaths.currentCountryFlagIconUrl }}" alt="" />
+        {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-flags-flag.' (i18n "currentCountryFlagKey")) }}
         <p>{{ i18n "currentCountryLocalisedName" }}</p>
-        <img class="c-countrySelector-chevron c-icon--chevron--small" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
+        {{> je-svg-sprite cssClass="c-countrySelector-chevron c-icon--chevron--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
     </button>
     <ul class="c-countrySelector-list is-hidden" data-toggle-name="countrySelector-list">
         {{#each (i18n "countries") as | country |}}
             <li>
                 <a class="c-countrySelector-link" target="_blank" href="{{ country.siteUrl }}">
-                    <img class="c-icon--flag--small" src="{{ lookup ../flagIconPaths country.flagUrl }}" alt="" />
+                    {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat (lookup ../svgSpriteModel 'iconsSpritePath') '#icons-flags-flag.' country.key) }}
                     <p>{{ country.localisedName }}</p>
                 </a>
             </li>
         {{/each}}
         <li>
             <button type="button" class="o-btn o-btnLink c-countrySelector-link c-countrySelector-link--selected" data-toggle-target="countrySelector-list">
-                <img class="c-icon--flag--small" src="{{ miscIconPaths.currentCountryFlagIconUrl }}" alt="" />
+                {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-flags-flag.' (i18n "currentCountryFlagKey")) }}
                 <p>{{ i18n "currentCountryLocalisedName" }}</p>
             </button>
             <button type="button" class="o-btnLink" data-toggle-target="countrySelector-list" aria-label="{{ i18n "buttonClose" }}">
-                <img class="c-countrySelector-cross" src="{{ miscIconPaths.crossIconUrl }}" alt="" />
+                {{> je-svg-sprite cssClass="c-countrySelector-cross" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-operators-cross') }}
             </button>
         </li>
     </ul>

--- a/src/templates/footer/partials/je-svg-sprite.hbs
+++ b/src/templates/footer/partials/je-svg-sprite.hbs
@@ -1,0 +1,3 @@
+<svg class="{{ cssClass }}" {{attributes}}>
+    <use xlink:href="{{ spriteUrl }}" xmlns:xlink="http://www.w3.org/1999/xlink"></use>
+</svg>

--- a/src/templates/footer/partials/payment-provider-links.hbs
+++ b/src/templates/footer/partials/payment-provider-links.hbs
@@ -2,6 +2,7 @@
     <ul class="c-footer-list c-footer-list--inline">
         {{#each (i18n "paymentIcons") as | paymentIcon |}}
             <li class="c-footer-list-item"> {{!-- missing 'certificate' logic --}}
+                {{!-- We can't use svg sprite here because of gradient effect which doesn't work with sprites in Chrome and Safari --}}
                 <img class="c-footer-icon c-footer-icon--{{ paymentIcon.type }} c-icon--{{ paymentIcon.key }}" src="{{ lookup ../paymentIconPaths paymentIcon.iconSrc }}" alt="{{ paymentIcon.altText }}" />
             </li>
         {{/each}}

--- a/src/templates/footer/partials/site-navigation-links.hbs
+++ b/src/templates/footer/partials/site-navigation-links.hbs
@@ -1,7 +1,7 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-1">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-1" data-toggle-class="is-collapsed">
         {{ i18n "customerService" }}
-        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
+        {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
     </h2>
 
     <ul class="c-footer-list">
@@ -14,7 +14,7 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-2">
     <h2 data-test-id="cuisine-footer-heading" class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-2" data-toggle-class="is-collapsed">
         {{ i18n "cuisines" }}
-        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
+        {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
     </h2>
 
     <ul class="c-footer-list">
@@ -27,7 +27,7 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-3">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-3" data-toggle-class="is-collapsed">
         {{ i18n "towns" }}
-        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
+        {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
     </h2>
 
     <ul class="c-footer-list">
@@ -40,7 +40,7 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-4">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-4" data-toggle-class="is-collapsed">
         {{ i18n "aboutUs" }}
-        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
+        {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
     </h2>
 
     <ul class="c-footer-list">

--- a/src/templates/resources/footer-docs-data.json
+++ b/src/templates/resources/footer-docs-data.json
@@ -1,19 +1,9 @@
 {
     "language": "en-GB",
-    "miscIconPaths": {
-        "chevronIconUrl": "/assets/img/icons/arrows/chevron.svg",
-        "crossIconUrl": "/assets/img/icons/operators/cross.svg",
-        "currentCountryFlagIconUrl": "/assets/img/icons/flags/flag.gb.svg"
+    "svgSpriteModel": {
+        "iconsSpritePath": "/assets/img/sprite.svg"
     },
-    "socialIconPaths": {
-        "facebookIconUrl": "/assets/img/icons/social/icon-facebook.svg",
-        "twitterIconUrl": "/assets/img/icons/social/icon-twitter.svg",
-        "instagramIconUrl": "/assets/img/icons/social/icon-instagram.svg",
-        "googlePlusIconUrl": "/assets/img/icons/social/icon-google-plus.svg",
-        "youtubeIconUrl": "/assets/img/icons/social/icon-youtube.svg",
-        "pinterestIconUrl": "/assets/img/icons/social/icon-pinterest.svg",
-        "rssIconUrl": "/assets/img/icons/social/icon-rss.svg"
-    },
+
     "appIconPaths": {
         "iosIconSrc": "/assets/img/icons/appstore/ios.svg",
         "androidIconSrc": "/assets/img/icons/appstore/android.svg",
@@ -27,19 +17,5 @@
         "paypalIconSrc": "/assets/img/icons/cards/paypal.svg",
         "confianzaIconSrc": "/assets/img/icons/cards/confianza.svg",
         "interacIconSrc": "/assets/img/icons/cards/interac.svg"
-    },
-    "flagIconPaths": {
-        "australiaFlagIconUrl": "/assets/img/icons/flags/flag.au.svg",
-        "brasilFlagIconUrl": "/assets/img/icons/flags/flag.br.svg",
-        "canadaFlagIconUrl": "/assets/img/icons/flags/flag.ca.svg",
-        "denmarkFlagIconUrl": "/assets/img/icons/flags/flag.dk.svg",
-        "franceFlagIconUrl": "/assets/img/icons/flags/flag.fr.svg",
-        "irelandFlagIconUrl": "/assets/img/icons/flags/flag.ie.svg",
-        "italyFlagIconUrl": "/assets/img/icons/flags/flag.it.svg",
-        "newzealandFlagIconUrl": "/assets/img/icons/flags/flag.nz.svg",
-        "norwayFlagIconUrl": "/assets/img/icons/flags/flag.no.svg",
-        "switzerlandFlagIconUrl": "/assets/img/icons/flags/flag.ch.svg",
-        "spainFlagIconUrl": "/assets/img/icons/flags/flag.es.svg",
-        "ukFlagIconUrl": "/assets/img/icons/flags/flag.gb.svg"
     }
 }

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -193,58 +193,70 @@
             }
         ],
         "currentCountryLocalisedName": "Danmark",
+        "currentCountryFlagKey": "dk",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australien",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brasilien",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "Canada",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "Frankrig",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Irland",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italien",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "New Zealand",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norge",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Schweiz",
                 "siteUrl": "https://www.eat.ch"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Spanien",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "gb",
                 "flagUrl": "ukFlagIconUrl",
                 "localisedName": "Storbritannien",
                 "siteUrl": "https://www.just-eat.co.uk"
@@ -445,58 +457,71 @@
             }
         ],
         "currentCountryLocalisedName": "España",
+        "currentCountryFlagKey": "es",
+
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australia",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brasil",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "Canadá",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Dinamarca",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "Francia",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Irlanda",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italia",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Noruega",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "Nueva Zelanda",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "gb",
                 "flagUrl": "ukFlagIconUrl",
                 "localisedName": "Reino Unido",
                 "siteUrl": "https://www.just-eat.co.uk"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Suiza",
                 "siteUrl": "https://www.eat.ch"
@@ -692,58 +717,70 @@
             }
         ],
         "currentCountryLocalisedName": "United Kingdom",
+        "currentCountryFlagKey": "gb",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australia",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brazil",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "Canada",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Denmark",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "France",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Ireland",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italy",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "New Zealand",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norway",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Spain",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
                 "siteUrl": "https://www.eat.ch"
@@ -932,58 +969,70 @@
             }
         ],
         "currentCountryLocalisedName": "Australia",
+        "currentCountryFlagKey": "au",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australia",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brazil",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "Canada",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Denmark",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "France",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Ireland",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italy",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "New Zealand",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norway",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Spain",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
                 "siteUrl": "https://www.eat.ch"
@@ -1129,58 +1178,70 @@
             }
         ],
         "currentCountryLocalisedName": "New Zealand",
+        "currentCountryFlagKey": "nz",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australia",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brazil",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "Canada",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Denmark",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "France",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Ireland",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italy",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "New Zealand",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norway",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Spain",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
                 "siteUrl": "https://www.eat.ch"
@@ -1361,58 +1422,70 @@
             }
         ],
         "currentCountryLocalisedName": "Italia",
+        "currentCountryFlagKey": "it",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australia",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brasile",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "Canada",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Danimarca",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "Francia",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Irlanda",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norvegia",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "Nuova Zelanda",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "gb",
                 "flagUrl": "ukFlagIconUrl",
                 "localisedName": "Regno Unito",
                 "siteUrl": "https://www.just-eat.co.uk"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Spagna",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Svizzera",
                 "siteUrl": "https://www.eat.ch"
@@ -1593,58 +1666,70 @@
             }
         ],
         "currentCountryLocalisedName": "Ireland",
+        "currentCountryFlagKey": "ie",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australia",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brazil",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "Canada",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Denmark",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "France",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italy",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "New Zealand",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norway",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Spain",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
                 "siteUrl": "https://www.eat.ch"
             },
             {
+                "key": "gb",
                 "flagUrl": "ukFlagIconUrl",
                 "localisedName": "United Kingdom",
                 "siteUrl": "https://www.just-eat.co.uk"
@@ -1811,58 +1896,70 @@
             }
         ],
         "currentCountryLocalisedName": "Norge",
+        "currentCountryFlagKey": "no",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australia",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brasil",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "Canada",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Danmark",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "Frankrike",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Irland",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italia",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "New Zealand",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Spania",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "gb",
                 "flagUrl": "ukFlagIconUrl",
                 "localisedName": "Storbritannia",
                 "siteUrl": "https://www.just-eat.co.uk"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Sveits",
                 "siteUrl": "https://www.eat.ch"
@@ -2073,58 +2170,70 @@
             }
         ],
         "currentCountryLocalisedName": "Canada",
+        "currentCountryFlagKey": "ca",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australia",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brazil",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Denmark",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "France",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Ireland",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italy",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "New Zealand",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norway",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Spain",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
                 "siteUrl": "https://www.eat.ch"
             },
             {
+                "key": "gb",
                 "flagUrl": "ukFlagIconUrl",
                 "localisedName": "United Kingdom",
                 "siteUrl": "https://www.just-eat.co.uk"
@@ -2331,58 +2440,70 @@
             }
         ],
         "currentCountryLocalisedName": "Canada",
+        "currentCountryFlagKey": "ca",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "Australie",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brésil",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "Danemark",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "Espagne",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "France",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "Irlande",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "Italie",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norvège",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "Nouvelle-Zélande",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "gb",
                 "flagUrl": "ukFlagIconUrl",
                 "localisedName": "Royaume-Uni",
                 "siteUrl": "https://www.just-eat.co.uk"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Suisse",
                 "siteUrl": "https://www.eat.ch"
@@ -2578,58 +2699,70 @@
             }
         ],
         "currentCountryLocalisedName": "[⁅Ûñîţéðẋẋ Ķîñĝðöɱẋẋẋ⁆ẋẋẋẋẋẋẋ]",
+        "currentCountryFlagKey": "gb",
         "countries": [
             {
+                "key": "au",
                 "flagUrl": "australiaFlagIconUrl",
                 "localisedName": "[Åûšţŕåļîåẋẋẋ]",
                 "siteUrl": "https://www.menulog.com.au"
             },
             {
+                "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "[Ɓŕåžîļẋẋ]",
                 "siteUrl": "https://www.ifood.com.br"
             },
             {
+                "key": "ca",
                 "flagUrl": "canadaFlagIconUrl",
                 "localisedName": "[Çåñåðåẋẋ]",
                 "siteUrl": "https://www.just-eat.ca"
             },
             {
+                "key": "dk",
                 "flagUrl": "denmarkFlagIconUrl",
                 "localisedName": "[Ðéñɱåŕķẋẋẋ]",
                 "siteUrl": "https://www.just-eat.dk"
             },
             {
+                "key": "fr",
                 "flagUrl": "franceFlagIconUrl",
                 "localisedName": "[Ƒŕåñçéẋẋ]",
                 "siteUrl": "https://www.just-eat.fr/"
             },
             {
+                "key": "ie",
                 "flagUrl": "irelandFlagIconUrl",
                 "localisedName": "[Îŕéļåñðẋẋẋ]",
                 "siteUrl": "https://www.just-eat.ie"
             },
             {
+                "key": "it",
                 "flagUrl": "italyFlagIconUrl",
                 "localisedName": "[Îţåļýẋẋ]",
                 "siteUrl": "https://www.justeat.it"
             },
             {
+                "key": "nz",
                 "flagUrl": "newzealandFlagIconUrl",
                 "localisedName": "[Ñéŵẋ Žéåļåñðẋẋẋ]",
                 "siteUrl": "https://www.menulog.co.nz"
             },
             {
+                "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "[Ñöŕŵåýẋẋ]",
                 "siteUrl": "https://www.just-eat.no"
             },
             {
+                "key": "es",
                 "flagUrl": "spainFlagIconUrl",
                 "localisedName": "[Šþåîñẋẋ]",
                 "siteUrl": "https://www.just-eat.es"
             },
             {
+                "key": "ch",
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "[Šŵîţžéŕļåñðẋẋẋẋ]",
                 "siteUrl": "https://www.eat.ch"


### PR DESCRIPTION
Replace existing footer icons rendering with svg sprite. Apps and payment methods icons left because some of them have gradient which doesn't work properly in svg sprite.