### PR TITLE
Added Amex card icon src, updated payment icons configuration for AU & NZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.8.3
+------------------------------
+*December 3, 2018*
+
+### Added
+- Amex icon (not SafeKey) in resource json file
+
+### Changed
+- Amex icon for AU & NZ footer template json
+
+### Removed
+- Paypal icon for NZ footer template json
+
+
 v1.8.2
 ------------------------------
 *November 29, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.10.0
 ------------------------------
-*December 3, 2018*
+*December 7, 2018*
 
 ### Added
 - Amex icon (not SafeKey) in resource json file
+- Visa icon in resource json file
+- MasterCard icon in resource json file
 
 ### Changed
-- Amex icon for AU & NZ footer template json
+- Amex, Visa & MasterCard icon for AU & NZ footer template json
 
 ### Removed
 - Paypal icon for NZ footer template json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v1.8.3
+v1.9.0
 ------------------------------
 *December 3, 2018*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v2.0.0
+v1.10.0
 ------------------------------
 *December 3, 2018*
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer-docs-data.json
+++ b/src/templates/resources/footer-docs-data.json
@@ -14,6 +14,7 @@
         "visaIconSrc": "/assets/img/icons/cards/visa--verified.svg",
         "mastercardIconSrc": "/assets/img/icons/cards/mastercard--securecode.svg",
         "amexIconSrc": "/assets/img/icons/cards/amex--safekey.svg",
+        "amexCardIconSrc": "/assets/img/icons/cards/amex.svg",
         "paypalIconSrc": "/assets/img/icons/cards/paypal.svg",
         "confianzaIconSrc": "/assets/img/icons/cards/confianza.svg",
         "interacIconSrc": "/assets/img/icons/cards/interac.svg"

--- a/src/templates/resources/footer-docs-data.json
+++ b/src/templates/resources/footer-docs-data.json
@@ -12,7 +12,9 @@
     "paymentIconPaths": {
         "dkIconSrc": "/assets/img/icons/cards/dk.svg",
         "visaIconSrc": "/assets/img/icons/cards/visa--verified.svg",
+        "visaCardIconSrc": "/assets/img/icons/cards/visa.svg",
         "mastercardIconSrc": "/assets/img/icons/cards/mastercard--securecode.svg",
+        "mastercardCardIconSrc": "/assets/img/icons/cards/mastercard.svg",
         "amexIconSrc": "/assets/img/icons/cards/amex--safekey.svg",
         "amexCardIconSrc": "/assets/img/icons/cards/amex.svg",
         "paypalIconSrc": "/assets/img/icons/cards/paypal.svg",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -945,14 +945,14 @@
         "paymentIcons": [
             {
                 "type": "card",
-                "key": "mastercard--securecode",
-                "iconSrc": "mastercardIconSrc",
+                "key": "mastercard",
+                "iconSrc": "mastercardCardIconSrc",
                 "altText": "Mastercard"
             },
             {
                 "type": "card",
-                "key": "visa--verified",
-                "iconSrc": "visaIconSrc",
+                "key": "visa",
+                "iconSrc": "visaCardIconSrc",
                 "altText": "Visa"
             },
             {
@@ -1154,14 +1154,14 @@
         "paymentIcons": [
             {
                 "type": "card",
-                "key": "mastercard--securecode",
-                "iconSrc": "mastercardIconSrc",
+                "key": "mastercard",
+                "iconSrc": "mastercardCardIconSrc",
                 "altText": "Mastercard"
             },
             {
                 "type": "card",
-                "key": "visa--verified",
-                "iconSrc": "visaIconSrc",
+                "key": "visa",
+                "iconSrc": "visaCardIconSrc",
                 "altText": "Visa"
             },
             {

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -957,8 +957,8 @@
             },
             {
                 "type": "card",
-                "key": "amex--safekey",
-                "iconSrc": "amexIconSrc",
+                "key": "amex",
+                "iconSrc": "amexCardIconSrc",
                 "altText": "American Express"
             },
             {
@@ -1166,15 +1166,9 @@
             },
             {
                 "type": "card",
-                "key": "amex--safekey",
-                "iconSrc": "amexIconSrc",
+                "key": "amex",
+                "iconSrc": "amexCardIconSrc",
                 "altText": "American Express"
-            },
-            {
-                "type": "card",
-                "key": "paypal",
-                "iconSrc": "paypalIconSrc",
-                "altText": "PayPal"
             }
         ],
         "currentCountryLocalisedName": "New Zealand",


### PR DESCRIPTION
https://jira.just-eat.net/browse/MCC-752

NON - CONSUMER WEB | Only show the payment methods offered by Menulog (platform/tenant) in the website footer

##### How it was
![screen shot 2018-12-04 at 11 31 35 am](https://user-images.githubusercontent.com/1910395/49410802-94f71a80-f7ba-11e8-87b6-7b0370f7071c.png)

##### How it will look like
![screen shot 2018-12-04 at 11 35 56 am](https://user-images.githubusercontent.com/1910395/49410824-acce9e80-f7ba-11e8-8f4c-a7ca1b192f7e.png)

##### Added
- Amex icon (not SafeKey) link in resource json file

##### Changed
- Amex icon for AU & NZ footer template json

##### Removed
- Paypal icon for NZ footer template json

### Browsers Tested

- [x] Chrome
