### PR TITLE
v1.8.1 - Fix translations & pseudo-locale code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.8.1
+------------------------------
+*November 10, 2018*
+
+### Fixed
+- Adding missing Danish, Italian and Norwegian translations.
+- Updated the casing of the pseudo-locale language code so it works with .NET Core on Linux.
+
+
 v1.8.0
 ------------------------------
 *November 6, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -2510,7 +2510,7 @@
             }
         ]
     },
-    "qps-ploc": {
+    "qps-Ploc": {
         "improveOurWebsite": "[Ĥéļþẋẋ ûšẋ îɱþŕöṽéẋẋẋ öûŕẋ ŵéƀšîţéẋẋẋ]",
         "sendFeedback": "[Šéñðẋẋ ƒééðƀåçķẋẋẋ]",
         "vatInfo": "",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1,6 +1,6 @@
 {
     "da-DK": {
-        "improveOurWebsite": "Help us improve our website",
+        "improveOurWebsite": "Hjælp os med at gøre vores hjemmeside bedre",
         "sendFeedback": "Send feedback",
         "vatInfo": "",
         "customerService": "Kundeservice",
@@ -1249,8 +1249,8 @@
         ]
     },
     "it-IT": {
-        "improveOurWebsite": "Help us improve our website",
-        "sendFeedback": "Send feedback",
+        "improveOurWebsite": "Aiutaci a migliorare il nostro sito",
+        "sendFeedback": "Invia feedback",
         "vatInfo": "",
         "customerService": "Servizio Clienti",
         "changeCurrentCountry": "Sei sul sito Italiano. Clicca qui per cambiare stato.",
@@ -1737,8 +1737,8 @@
         ]
     },
     "nb-NO": {
-        "improveOurWebsite": "Help us improve our website",
-        "sendFeedback": "Send feedback",
+        "improveOurWebsite": "Hjelp oss med å gjøre vår hjemmeside bedre",
+        "sendFeedback": "Send tilbakemelding",
         "vatInfo": "",
         "customerService": "Kundeservice",
         "changeCurrentCountry": "Du er på den norske nettsiden. Klikk her for å endre.",


### PR DESCRIPTION
  1. Add missing feedback translations for Denmark, Italy and Norway.
  1. Fix the casing of the pseudo-locale added by #54 so it works on Linux for .NET Core (see martincostello/aspnet-core-pseudo-localization#6).