### PR TITLE
v1.9.0 - rollback svg sprite change to f-footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,26 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.9.0
+------------------------------
+*December 5, 2018*
+
+### Changed
+- Temporarily roll back svg sprite change to footer icons.
+
+This version needs WebBoilerplate >= v1.0.78
+
+### Fixed
+- Babel resolution set to fix JS unit tests.
+
 v1.8.2
 ------------------------------
 *November 29, 2018*
 
 ### Fixed
 - Fixed incorrect footer links and link text.
+
 
 v1.8.1
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",
@@ -40,6 +40,7 @@
     "js-test-buddy": "0.1.0"
   },
   "resolutions": {
+    "babel-core": "7.0.0-bridge.0",
     "espree": "3.5.4"
   },
   "keywords": [

--- a/src/templates/footer/partials/apps-and-social-links.hbs
+++ b/src/templates/footer/partials/apps-and-social-links.hbs
@@ -20,7 +20,9 @@
         {{#each (i18n "socialIcons") as | socialIcon |}}
             <li class="c-footer-list-item">
                 <a href="{{ socialIcon.url }}" target="_blank">
-                    {{> je-svg-sprite cssClass="c-footer-icon c-footer-icon--social" spriteUrl=(concat (lookup ../svgSpriteModel 'iconsSpritePath') '#icons-social-icon-' socialIcon.key) }}
+                    {{!-- temporarily return back previos img solution untill WH-692 is fixed --}}
+                    {{!-- {{> je-svg-sprite cssClass="c-footer-icon c-footer-icon--social" spriteUrl=(concat (lookup ../svgSpriteModel 'iconsSpritePath') '#icons-social-icon-' socialIcon.key) }} --}}
+                    <img class="c-footer-icon c-footer-icon--social" src="{{ lookup ../socialIconPaths socialIcon.iconSrc }}" alt="{{ socialIcon.altText }}" />
                 </a>
             </li>
         {{/each}}

--- a/src/templates/footer/partials/country-selector.hbs
+++ b/src/templates/footer/partials/country-selector.hbs
@@ -1,25 +1,31 @@
 <div class="c-countrySelector">
     <button type="button" class="o-btn o-btnLink c-countrySelector-link c-countrySelector-link--selected" data-toggle-target="countrySelector-list" aria-label="{{ i18n "changeCurrentCountry" }}">
-        {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-flags-flag.' (i18n "currentCountryFlagKey")) }}
+        {{!-- temporarily return back previos img solution untill WH-692 is fixed --}}
+        {{!-- {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-flags-flag.' (i18n "currentCountryFlagKey")) }} --}}
+        <img class="c-icon--flag--small" src="{{ miscIconPaths.currentCountryFlagIconUrl }}" alt="" />
         <p>{{ i18n "currentCountryLocalisedName" }}</p>
-        {{> je-svg-sprite cssClass="c-countrySelector-chevron c-icon--chevron--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
+        {{!-- {{> je-svg-sprite cssClass="c-countrySelector-chevron c-icon--chevron--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
+        <img class="c-countrySelector-chevron c-icon--chevron--small" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </button>
     <ul class="c-countrySelector-list is-hidden" data-toggle-name="countrySelector-list">
         {{#each (i18n "countries") as | country |}}
             <li>
                 <a class="c-countrySelector-link" target="_blank" href="{{ country.siteUrl }}">
-                    {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat (lookup ../svgSpriteModel 'iconsSpritePath') '#icons-flags-flag.' country.key) }}
+                    {{!-- {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat (lookup ../svgSpriteModel 'iconsSpritePath') '#icons-flags-flag.' country.key) }} --}}
+                    <img class="c-icon--flag--small" src="{{ lookup ../flagIconPaths country.flagUrl }}" alt="" />
                     <p>{{ country.localisedName }}</p>
                 </a>
             </li>
         {{/each}}
         <li>
             <button type="button" class="o-btn o-btnLink c-countrySelector-link c-countrySelector-link--selected" data-toggle-target="countrySelector-list">
-                {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-flags-flag.' (i18n "currentCountryFlagKey")) }}
+                {{!-- {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-flags-flag.' (i18n "currentCountryFlagKey")) }} --}}
+                <img class="c-icon--flag--small" src="{{ miscIconPaths.currentCountryFlagIconUrl }}" alt="" />
                 <p>{{ i18n "currentCountryLocalisedName" }}</p>
             </button>
             <button type="button" class="o-btnLink" data-toggle-target="countrySelector-list" aria-label="{{ i18n "buttonClose" }}">
-                {{> je-svg-sprite cssClass="c-countrySelector-cross" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-operators-cross') }}
+                {{!-- {{> je-svg-sprite cssClass="c-countrySelector-cross" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-operators-cross') }} --}}
+                <img class="c-countrySelector-cross" src="{{ miscIconPaths.crossIconUrl }}" alt="" />
             </button>
         </li>
     </ul>

--- a/src/templates/footer/partials/site-navigation-links.hbs
+++ b/src/templates/footer/partials/site-navigation-links.hbs
@@ -1,7 +1,8 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-1">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-1" data-toggle-class="is-collapsed">
         {{ i18n "customerService" }}
-        {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
+        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
+        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
     <ul class="c-footer-list">
@@ -14,7 +15,8 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-2">
     <h2 data-test-id="cuisine-footer-heading" class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-2" data-toggle-class="is-collapsed">
         {{ i18n "cuisines" }}
-        {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
+        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
+        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
     <ul class="c-footer-list">
@@ -27,7 +29,8 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-3">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-3" data-toggle-class="is-collapsed">
         {{ i18n "towns" }}
-        {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
+        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
+        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
     <ul class="c-footer-list">
@@ -40,7 +43,8 @@
 <div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-4">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-4" data-toggle-class="is-collapsed">
         {{ i18n "aboutUs" }}
-        {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }}
+        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowMid" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
+        <img class="c-footer-chevron c-icon--chevron u-showBelowMid" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
     <ul class="c-footer-list">

--- a/src/templates/resources/footer-docs-data.json
+++ b/src/templates/resources/footer-docs-data.json
@@ -3,7 +3,34 @@
     "svgSpriteModel": {
         "iconsSpritePath": "/assets/img/sprite.svg"
     },
-
+    "miscIconPaths": {
+      "chevronIconUrl": "/assets/img/icons/arrows/chevron.svg",
+      "crossIconUrl": "/assets/img/icons/operators/cross.svg",
+      "currentCountryFlagIconUrl": "/assets/img/icons/flags/flag.gb.svg"
+    },
+    "socialIconPaths": {
+        "facebookIconUrl": "/assets/img/icons/social/icon-facebook.svg",
+        "twitterIconUrl": "/assets/img/icons/social/icon-twitter.svg",
+        "instagramIconUrl": "/assets/img/icons/social/icon-instagram.svg",
+        "googlePlusIconUrl": "/assets/img/icons/social/icon-google-plus.svg",
+        "youtubeIconUrl": "/assets/img/icons/social/icon-youtube.svg",
+        "pinterestIconUrl": "/assets/img/icons/social/icon-pinterest.svg",
+        "rssIconUrl": "/assets/img/icons/social/icon-rss.svg"
+    },
+    "flagIconPaths": {
+        "australiaFlagIconUrl": "/assets/img/icons/flags/flag.au.svg",
+        "brasilFlagIconUrl": "/assets/img/icons/flags/flag.br.svg",
+        "canadaFlagIconUrl": "/assets/img/icons/flags/flag.ca.svg",
+        "denmarkFlagIconUrl": "/assets/img/icons/flags/flag.dk.svg",
+        "franceFlagIconUrl": "/assets/img/icons/flags/flag.fr.svg",
+        "irelandFlagIconUrl": "/assets/img/icons/flags/flag.ie.svg",
+        "italyFlagIconUrl": "/assets/img/icons/flags/flag.it.svg",
+        "newzealandFlagIconUrl": "/assets/img/icons/flags/flag.nz.svg",
+        "norwayFlagIconUrl": "/assets/img/icons/flags/flag.no.svg",
+        "switzerlandFlagIconUrl": "/assets/img/icons/flags/flag.ch.svg",
+        "spainFlagIconUrl": "/assets/img/icons/flags/flag.es.svg",
+        "ukFlagIconUrl": "/assets/img/icons/flags/flag.gb.svg"
+    },
     "appIconPaths": {
         "iosIconSrc": "/assets/img/icons/appstore/ios.svg",
         "androidIconSrc": "/assets/img/icons/appstore/android.svg",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,31 +1554,11 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
-  version "6.26.3"
-  resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-generator "^6.26.0"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    convert-source-map "^1.5.1"
-    debug "^2.6.9"
-    json5 "^0.5.1"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    path-is-absolute "^1.0.1"
-    private "^0.1.8"
-    slash "^1.0.0"
-    source-map "^0.5.7"
+babel-core@7.0.0-bridge.0, babel-core@^6.0.0:
+  version "7.0.0-bridge.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
 
-babel-generator@^6.18.0, babel-generator@^6.26.0:
+babel-generator@^6.18.0:
   version "6.26.1"
   resolved "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
   dependencies:
@@ -1590,13 +1570,6 @@ babel-generator@^6.18.0, babel-generator@^6.26.0:
     lodash "^4.17.4"
     source-map "^0.5.7"
     trim-right "^1.0.1"
-
-babel-helpers@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
 
 babel-jest@^23.6.0:
   version "23.6.0"
@@ -1635,18 +1608,6 @@ babel-preset-jest@^23.2.0:
     babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
-babel-register@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
-  dependencies:
-    babel-core "^6.26.0"
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.17.4"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.15"
-
 babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
@@ -1654,7 +1615,7 @@ babel-runtime@^6.22.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.16.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -3067,7 +3028,7 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
-convert-source-map@1.X, convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.1:
+convert-source-map@1.X, convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.4.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   dependencies:
@@ -3085,7 +3046,7 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
+core-js@^2.4.0, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
@@ -6013,13 +5974,6 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-home-or-tmp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.1"
-
 homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
@@ -7472,7 +7426,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json5@^0.5.0, json5@^0.5.1:
+json5@^0.5.0:
   version "0.5.1"
   resolved "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
@@ -9270,7 +9224,7 @@ os-shim@^0.1.2:
   version "0.1.3"
   resolved "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -10101,7 +10055,7 @@ pretty-time@^0.2.0:
     is-number "^2.0.2"
     nanoseconds "^0.1.0"
 
-private@^0.1.6, private@^0.1.8:
+private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.npmjs.org/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -11360,12 +11314,6 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
-
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  dependencies:
-    source-map "^0.5.6"
 
 source-map-support@^0.5.6, source-map-support@~0.5.6:
   version "0.5.9"


### PR DESCRIPTION
### Changed
- Temporarily roll back svg sprite change to footer icons to fix WH-692.

This version needs WebBoilerplate >= v1.0.78

### Fixed
- Babel resolution set to fix JS unit tests.