### PR TITLE
v1.9.1 - Adding a "Become a Driver" footer link for Italy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.9.1
+------------------------------
+*December 18, 2018*
+
+### Added
+- New footer link for Italy to become a driver partner.
 
 v1.9.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1362,6 +1362,10 @@
                 "text": "Lavora con noi"
             },
             {
+                "url": "https://www.justeat.it/domicilio/driver-partner",
+                "text": "Diventa un Rider"
+            },
+            {
                 "url": "/press-info",
                 "text": "Area stampa"
             },


### PR DESCRIPTION
Adding a "Become a Driver" ("Diventa un Rider") footer link to the Italy tenant.

## UI Review Checks

![image](https://user-images.githubusercontent.com/10439518/50164249-09ad7700-02da-11e9-8311-1b5140687b0b.png)

- [x] This PR has been checked with regard to our brand guidelines
- [x] UI Documentation has been [created|updated]