### PR TITLE
v1.12.0 - Update footer links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.12.0
+------------------------------
+*February 6, 2019*
+
+### Changed
+- Updated links for popular locations
+- Updated links for popular cuisines
+
+
 v1.11.0
 ------------------------------
 *January 18, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -568,50 +568,50 @@
         "cuisines": "Top cuisines",
         "cuisineLinks": [
             {
-                "url": "/chinese-takeaways",
+                "url": "/takeaway/nearme/chinese",
                 "text": "Chinese"
             },
             {
-                "url": "/indian-takeaways",
+                "url": "/takeaway/nearme/indian",
                 "text": "Indian"
             },
             {
-                "url": "/italian-takeaways",
+                "url": "/takeaway/nearme/italian",
                 "text": "Italian"
             },
             {
-                "url": "/japanese-takeaways",
+                "url": "/takeaway/nearme/sushi",
                 "text": "Japanese"
             },
             {
-                "url": "/pizza-delivery",
+                "url": "/takeaway/nearme/pizza",
                 "text": "Pizza delivery"
             },
             {
-                "url": "/cuisine",
+                "url": "/takeaway/nearme",
                 "text": "View all cuisines"
             }
         ],
         "towns": "Locations",
         "locationLinks": [
             {
-                "url": "/birmingham-takeaway",
+                "url": "/takeaway/birmingham",
                 "text": "Birmingham"
             },
             {
-                "url": "/cardiff-takeaway",
+                "url": "/takeaway/cardiff",
                 "text": "Cardiff"
             },
             {
-                "url": "/glasgow-takeaway",
+                "url": "/takeaway/glasgow",
                 "text": "Glasgow"
             },
             {
-                "url": "/leeds-takeaway",
+                "url": "/takeaway/leeds",
                 "text": "Leeds"
             },
             {
-                "url": "/manchester-takeaway",
+                "url": "/takeaway/manchester",
                 "text": "Manchester"
             },
             {
@@ -2544,50 +2544,50 @@
         "cuisines": "[Ţöþẋ çûîšîñéšẋẋẋ]",
         "cuisineLinks": [
             {
-                "url": "/chinese-takeaways",
+                "url": "/takeaway/nearme/chinese",
                 "text": "[Çĥîñéšéẋẋẋ]"
             },
             {
-                "url": "/indian-takeaways",
+                "url": "/takeaway/nearme/indian",
                 "text": "[Îñðîåñẋẋ]"
             },
             {
-                "url": "/italian-takeaways",
+                "url": "/takeaway/nearme/italian",
                 "text": "[Îţåļîåñẋẋẋ]"
             },
             {
-                "url": "/japanese-takeaways",
+                "url": "/takeaway/nearme/sushi",
                 "text": "[Ĵåþåñéšéẋẋẋ]"
             },
             {
-                "url": "/pizza-delivery",
+                "url": "/takeaway/nearme/pizza",
                 "text": "[Þîžžåẋẋ ðéļîṽéŕýẋẋẋ]"
             },
             {
-                "url": "/cuisine",
+                "url": "/takeaway/nearme",
                 "text": "[Ṽîéŵẋẋ åļļẋ çûîšîñéšẋẋẋ]"
             }
         ],
         "towns": "[Ļöçåţîöñšẋẋẋ]",
         "locationLinks": [
             {
-                "url": "/birmingham-takeaway",
+                "url": "/takeaway/birmingham",
                 "text": "[Ɓîŕɱîñĝĥåɱẋẋẋẋ]"
             },
             {
-                "url": "/cardiff-takeaway",
+                "url": "/takeaway/cardiff",
                 "text": "[Çåŕðîƒƒẋẋẋ]"
             },
             {
-                "url": "/glasgow-takeaway",
+                "url": "/takeaway/glasgow",
                 "text": "[Ĝļåšĝöŵẋẋẋ]"
             },
             {
-                "url": "/leeds-takeaway",
+                "url": "/takeaway/leeds",
                 "text": "[Ļééðšẋẋ]"
             },
             {
-                "url": "/manchester-takeaway",
+                "url": "/takeaway/manchester",
                 "text": "[Ṁåñçĥéšţéŕẋẋẋẋ]"
             },
             {


### PR DESCRIPTION
Updated footer links to point to the new area and cuisine landing pages.

Link updates only, no copy or markup changes.