### PR TITLE
v1.15.0 - Use latest links for popular cuisines and locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.15.0
+------------------------------
+*February 19, 2019*
+
+### Changed
+- Re-updated links for popular locations
+- Re-updated links for popular cuisines
+
+
 v1.14.0
 ------------------------------
 *February 13, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -568,50 +568,50 @@
         "cuisines": "Top cuisines",
         "cuisineLinks": [
             {
-                "url": "/chinese-takeaways",
+                "url": "/takeaway/nearme/chinese",
                 "text": "Chinese"
             },
             {
-                "url": "/indian-takeaways",
+                "url": "/takeaway/nearme/indian",
                 "text": "Indian"
             },
             {
-                "url": "/italian-takeaways",
+                "url": "/takeaway/nearme/italian",
                 "text": "Italian"
             },
             {
-                "url": "/japanese-takeaways",
+                "url": "/takeaway/nearme/sushi",
                 "text": "Japanese"
             },
             {
-                "url": "/pizza-takeaways",
-                "text": "Pizza delivery"
+                "url": "/takeaway/nearme/pizza",
+                "text": "Pizza"
             },
             {
-                "url": "/cuisine",
+                "url": "/takeaway/nearme",
                 "text": "View all cuisines"
             }
         ],
         "towns": "Locations",
         "locationLinks": [
             {
-                "url": "/birmingham-takeaway",
+                "url": "/takeaway/birmingham",
                 "text": "Birmingham"
             },
             {
-                "url": "/cardiff-takeaway",
+                "url": "/takeaway/cardiff",
                 "text": "Cardiff"
             },
             {
-                "url": "/glasgow-takeaway",
+                "url": "/takeaway/glasgow",
                 "text": "Glasgow"
             },
             {
-                "url": "/leeds-takeaway",
+                "url": "/takeaway/leeds",
                 "text": "Leeds"
             },
             {
-                "url": "/manchester-takeaway",
+                "url": "/takeaway/manchester",
                 "text": "Manchester"
             },
             {
@@ -2544,50 +2544,50 @@
         "cuisines": "[Ţöþẋ çûîšîñéšẋẋẋ]",
         "cuisineLinks": [
             {
-                "url": "/chinese-takeaways",
+                "url": "/takeaway/nearme/chinese",
                 "text": "[Çĥîñéšéẋẋẋ]"
             },
             {
-                "url": "/indian-takeaways",
+                "url": "/takeaway/nearme/indian",
                 "text": "[Îñðîåñẋẋ]"
             },
             {
-                "url": "/italian-takeaways",
+                "url": "/takeaway/nearme/italian",
                 "text": "[Îţåļîåñẋẋẋ]"
             },
             {
-                "url": "/sushi-takeaways",
+                "url": "/takeaway/nearme/sushi",
                 "text": "[Ĵåþåñéšéẋẋẋ]"
             },
             {
-                "url": "/pizza-takeaways",
-                "text": "[Þîžžåẋẋ ðéļîṽéŕýẋẋẋ]"
+                "url": "/takeaway/nearme/pizza",
+                "text": "[Þîžžåẋẋ]"
             },
             {
-                "url": "/cuisine",
+                "url": "/takeaway/nearme",
                 "text": "[Ṽîéŵẋẋ åļļẋ çûîšîñéšẋẋẋ]"
             }
         ],
         "towns": "[Ļöçåţîöñšẋẋẋ]",
         "locationLinks": [
             {
-                "url": "/birmingham-takeaway",
+                "url": "/takeaway/birmingham",
                 "text": "[Ɓîŕɱîñĝĥåɱẋẋẋẋ]"
             },
             {
-                "url": "/cardiff-takeaway",
+                "url": "/takeaway/cardiff",
                 "text": "[Çåŕðîƒƒẋẋẋ]"
             },
             {
-                "url": "/glasgow-takeaway",
+                "url": "/takeaway/glasgow",
                 "text": "[Ĝļåšĝöŵẋẋẋ]"
             },
             {
-                "url": "/leeds-takeaway",
+                "url": "/takeaway/leeds",
                 "text": "[Ļééðšẋẋ]"
             },
             {
-                "url": "/manchester-takeaway",
+                "url": "/takeaway/manchester",
                 "text": "[Ṁåñçĥéšţéŕẋẋẋẋ]"
             },
             {

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -581,7 +581,7 @@
             },
             {
                 "url": "/takeaway/nearme/sushi",
-                "text": "Japanese"
+                "text": "Sushi"
             },
             {
                 "url": "/takeaway/nearme/pizza",
@@ -2557,7 +2557,7 @@
             },
             {
                 "url": "/takeaway/nearme/sushi",
-                "text": "[Ĵåþåñéšéẋẋẋ]"
+                "text": "[Šûšĥîẋẋ]"
             },
             {
                 "url": "/takeaway/nearme/pizza",


### PR DESCRIPTION
Now the new pages are available on the beta site, we can update the footer links to point to them.
Changing urls in the config file, so it shouldn't be browser-dependent.

## Browsers Tested

- [x] Chrome
- [ ] Safari
- [ ] IE 11
- [ ] Firefox
- [ ] Mobile (i.e. iPhone/Android - please list device)