### PR TITLE
v1.16.0 - Add `rel="nofollow"` to login link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.16.0
+------------------------------
+*March 6, 2019*
+
+### Added
+- Added optional `rel` attribute to site navigation links
+
+
 v1.15.0
 ------------------------------
 *February 19, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/footer/partials/site-navigation-links.hbs
+++ b/src/templates/footer/partials/site-navigation-links.hbs
@@ -7,7 +7,11 @@
 
     <ul class="c-footer-list">
         {{#each (i18n "links") as | link |}}
-            <li><a href="{{ link.url }}">{{ link.text }}</a></li>
+            <li>
+                <a href="{{ link.url }}" {{#if link.rel}}rel="{{ link.rel }}"{{/if}}>
+                    {{ link.text }}
+                </a>
+            </li>
         {{/each}}
     </ul>
 </div>

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -542,7 +542,8 @@
             },
             {
                 "url": "/account/login",
-                "text": "Log in"
+                "text": "Log in",
+                "rel": "nofollow"
             },
             {
                 "url": "/account/register",
@@ -1256,7 +1257,8 @@
             },
             {
                 "url": "/account/login",
-                "text": "Accedi"
+                "text": "Accedi",
+                "rel": "nofollow"
             },
             {
                 "url": "/account/register",
@@ -1748,7 +1750,8 @@
             },
             {
                 "url": "/account/login",
-                "text": "Logg inn"
+                "text": "Logg inn",
+                "rel": "nofollow"
             },
             {
                 "url": "/account/register",
@@ -2518,7 +2521,8 @@
             },
             {
                 "url": "/account/login",
-                "text": "[Ļöĝẋ îñẋ]"
+                "text": "[Ļöĝẋ îñẋ]",
+                "rel": "nofollow"
             },
             {
                 "url": "/account/register",


### PR DESCRIPTION
Adding `rel="nofollow"` to login link this so that Google bot doesn't try and crawl the login page.

## UI Review Checks
- [x] This code has been checked with regard to our accessibility standards
  - [x] HTML is valid [[link]](https://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlvalid)

_Only added one attribute so no accessibility/UI concerns, but HTML has been checked and has not affected page validity._

## Browsers Tested
- [x] Chrome
- [ ] Safari
- [x] IE 11
- [x] Firefox
- [ ] Mobile (i.e. iPhone/Android - please list device)