### PR TITLE
v1.19.0 - Updated AU/NZ country selector and some other links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.19.0
+------------------------------
+*April 30, 2019*
+
+### Added
+- United Kingdom to Australia and New Zealand's country selectors
+
+### Removed
+- New Zealand from New Zealand's country selector
+- Australia from Australia's country selector
+
+### Updated
+- Old (http) or dead links in footer.
+
+
 v1.18.1
 ------------------------------
 *April 15, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/footer/partials/country-selector.hbs
+++ b/src/templates/footer/partials/country-selector.hbs
@@ -1,9 +1,9 @@
 <div class="c-countrySelector">
-    <button type="button" class="o-btn o-btnLink c-countrySelector-link c-countrySelector-link--selected" data-toggle-target="countrySelector-list" aria-label="{{ i18n "changeCurrentCountry" }}">
+    <button type="button" class="o-btn o-btnLink c-countrySelector-link c-countrySelector-link--selected" data-toggle-target="countrySelector-list" data-test-id="countrySelector-button" aria-label="{{ i18n "changeCurrentCountry" }}">
         {{!-- temporarily return back previos img solution untill WH-692 is fixed --}}
         {{!-- {{> je-svg-sprite cssClass="c-icon--flag--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath '#icons-flags-flag.' (i18n "currentCountryFlagKey")) }} --}}
         <img class="c-icon--flag--small" src="{{ miscIconPaths.currentCountryFlagIconUrl }}" alt="" />
-        <p>{{ i18n "currentCountryLocalisedName" }}</p>
+        <p data-test-id="countrySelector-current-country">{{ i18n "currentCountryLocalisedName" }}</p>
         {{!-- {{> je-svg-sprite cssClass="c-countrySelector-chevron c-icon--chevron--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-countrySelector-chevron c-icon--chevron--small" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </button>

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1847,7 +1847,7 @@
         "aboutUs": "Om oss",
         "aboutUsLinks": [
             {
-                "url": "https://www.just-eat.no/take-away/bedrift-overtidsmat",
+                "url": "/take-away/bedrift-overtidsmat",
                 "text": "Restaurant påmelding"
             },
             {

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -24,7 +24,7 @@
                 "text": "Firmaaftale"
             },
             {
-                "url": "http://blog.just-eat.dk/",
+                "url": "/blog",
                 "text": "Just Eat Blog"
             },
             {
@@ -101,7 +101,7 @@
         "aboutUs": "Om os",
         "aboutUsLinks": [
             {
-                "url": "http://justeat-partner.dk/",
+                "url": "https://restaurants.just-eat.dk/",
                 "text": "Restaurant påmelding"
             },
             {
@@ -1001,12 +1001,6 @@
         "currentCountryFlagKey": "au",
         "countries": [
             {
-                "key": "au",
-                "flagUrl": "australiaFlagIconUrl",
-                "localisedName": "Australia",
-                "siteUrl": "https://www.menulog.com.au"
-            },
-            {
                 "key": "br",
                 "flagUrl": "brasilFlagIconUrl",
                 "localisedName": "Brazil",
@@ -1065,6 +1059,12 @@
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
                 "siteUrl": "https://www.eat.ch"
+            },
+            {
+                "key": "gb",
+                "flagUrl": "ukFlagIconUrl",
+                "localisedName": "United Kingdom",
+                "siteUrl": "https://www.just-eat.co.uk"
             }
         ]
     },
@@ -1250,12 +1250,6 @@
                 "siteUrl": "https://www.justeat.it"
             },
             {
-                "key": "nz",
-                "flagUrl": "newzealandFlagIconUrl",
-                "localisedName": "New Zealand",
-                "siteUrl": "https://www.menulog.co.nz"
-            },
-            {
                 "key": "no",
                 "flagUrl": "norwayFlagIconUrl",
                 "localisedName": "Norway",
@@ -1272,6 +1266,12 @@
                 "flagUrl": "switzerlandFlagIconUrl",
                 "localisedName": "Switzerland",
                 "siteUrl": "https://www.eat.ch"
+            },
+            {
+                "key": "gb",
+                "flagUrl": "ukFlagIconUrl",
+                "localisedName": "United Kingdom",
+                "siteUrl": "https://www.just-eat.co.uk"
             }
         ]
     },
@@ -1545,7 +1545,7 @@
                 "text": "Price Promise"
             },
             {
-                "url": "http://www.getmoreorders.ie/",
+                "url": "https://restaurants.just-eat.ie/",
                 "text": "Restaurant sign-up"
             },
             {
@@ -1895,7 +1895,7 @@
                 "altText": ""
             },
             {
-                "url": "http://blog.just-eat.no/",
+                "url": "/blog",
                 "key": "rss",
                 "iconSrc": "rssIconUrl",
                 "altText": ""


### PR DESCRIPTION
Fixed the content of the country selectors for Australia and New Zealand.
Updated some of the old http links.

## Browsers Tested
- [x] Chrome
- [ ] Safari
- [ ] IE 11
- [ ] Firefox
- [ ] Mobile (i.e. iPhone/Android - please list device)