### PR TITLE
v1.19.1 - Add another data-test-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.19.1
+------------------------------
+*May 1, 2019*
+
+### Added
+- `data-test-id` to country selector list
+
+
 v1.19.0
 ------------------------------
 *April 30, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/footer/partials/country-selector.hbs
+++ b/src/templates/footer/partials/country-selector.hbs
@@ -7,7 +7,7 @@
         {{!-- {{> je-svg-sprite cssClass="c-countrySelector-chevron c-icon--chevron--small" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-countrySelector-chevron c-icon--chevron--small" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </button>
-    <ul class="c-countrySelector-list is-hidden" data-toggle-name="countrySelector-list">
+    <ul class="c-countrySelector-list is-hidden" data-toggle-name="countrySelector-list" data-test-id="countrySelector-list">
         {{#each (i18n "countries") as | country |}}
             <li>
                 <a class="c-countrySelector-link" href="{{ country.siteUrl }}">


### PR DESCRIPTION
Adding another `data-test-id` for... testing purposes.

## Browsers Tested
- [x] Chrome
- [ ] Safari
- [ ] IE 11
- [ ] Firefox
- [ ] Mobile (i.e. iPhone/Android - please list device)