### PR TITLE
v1.20.0 Update footer content for Australia, New Zealand, Spain and Italy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules/*
 *.esproj
 *.sublime-*
 .vscode
+.vs
 nbproject
 Thumbs.db
 logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v1.19.0
+v1.20.0
 ------------------------------
-*April 26, 2019*
+*May 07, 2019*
 
 ### Added
-- "Updated footer content for Australia and New Zealand"
-- "Added brands list which is populated for Australia, empty for other tenants"
+- "Updated footer content for Australia, New Zealand, Italy and Spain"
+- "Added brands list which is populated for Australia, empty for all other tenants"
 - "Brands list only shows up when it has been setup with at least one brand for the tenant"
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.18.2
+------------------------------
+*April 26, 2019*
+
+### Added
+- "Updated footer content for Australia and New Zealand"
+
 
 v1.19.1
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ v1.20.0
 *May 07, 2019*
 
 ### Added
-- "Updated footer content for Australia, New Zealand, Italy and Spain"
-- "Added brands list which is populated for Australia, empty for all other tenants"
-- "Brands list only shows up when it has been setup with at least one brand for the tenant"
+- Updated footer content for Australia, New Zealand, Italy and Spain
+- Added brands list which is populated for Australia, empty for all other tenants
+- Brands list only shows up when it has been setup with at least one brand for the tenant
 
 
 v1.19.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-v1.18.2
+v1.19.0
 ------------------------------
 *April 26, 2019*
 
 ### Added
 - "Updated footer content for Australia and New Zealand"
+- "Added brands list which is populated for Australia, empty for other tenants"
+- "Brands list only shows up when it has been setup with at least one brand for the tenant"
 
 
 v1.19.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/footer/partials/site-navigation-links.hbs
+++ b/src/templates/footer/partials/site-navigation-links.hbs
@@ -31,7 +31,7 @@
 </div>
 
 {{#if (i18n "brandLinks")}}
-<div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-3">
+<div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-3" data-test-id="Footer-Brands-Column">
     <h2 data-test-id="brands-footer-heading" class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-3" data-toggle-class="is-collapsed">
         {{ i18n "brands" }}
         {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}

--- a/src/templates/footer/partials/site-navigation-links.hbs
+++ b/src/templates/footer/partials/site-navigation-links.hbs
@@ -1,7 +1,6 @@
 <div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-1">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-1" data-toggle-class="is-collapsed">
         {{ i18n "customerService" }}
-        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-footer-chevron c-icon--chevron u-showBelowWide" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
@@ -19,7 +18,6 @@
 <div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-2">
     <h2 data-test-id="cuisine-footer-heading" class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-2" data-toggle-class="is-collapsed">
         {{ i18n "cuisines" }}
-        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-footer-chevron c-icon--chevron u-showBelowWide" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
@@ -34,7 +32,6 @@
 <div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-3" data-test-id="Footer-Brands-Column">
     <h2 data-test-id="brands-footer-heading" class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-3" data-toggle-class="is-collapsed">
         {{ i18n "brands" }}
-        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-footer-chevron c-icon--chevron u-showBelowWide" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
@@ -49,7 +46,6 @@
 <div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-4">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-4" data-toggle-class="is-collapsed">
         {{ i18n "towns" }}
-        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-footer-chevron c-icon--chevron u-showBelowWide" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 
@@ -63,7 +59,6 @@
 <div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-5">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-5" data-toggle-class="is-collapsed">
         {{ i18n "aboutUs" }}
-        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-footer-chevron c-icon--chevron u-showBelowWide" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
     </h2>
 

--- a/src/templates/footer/partials/site-navigation-links.hbs
+++ b/src/templates/footer/partials/site-navigation-links.hbs
@@ -1,4 +1,4 @@
-<div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-1">
+<div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-1">
     <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-1" data-toggle-class="is-collapsed">
         {{ i18n "customerService" }}
         {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
@@ -16,7 +16,7 @@
     </ul>
 </div>
 
-<div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-2">
+<div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-2">
     <h2 data-test-id="cuisine-footer-heading" class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-2" data-toggle-class="is-collapsed">
         {{ i18n "cuisines" }}
         {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
@@ -30,8 +30,24 @@
     </ul>
 </div>
 
-<div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-3">
-    <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-3" data-toggle-class="is-collapsed">
+{{#if (i18n "brandLinks")}}
+<div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-3">
+    <h2 data-test-id="brands-footer-heading" class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-3" data-toggle-class="is-collapsed">
+        {{ i18n "brands" }}
+        {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
+        <img class="c-footer-chevron c-icon--chevron u-showBelowWide" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
+    </h2>
+
+    <ul class="c-footer-list">
+        {{#each (i18n "brandLinks") as | brandLink |}}
+            <li><a href="{{ brandLink.url }}">{{ brandLink.text }}</a></li>
+        {{/each}}
+    </ul>
+</div>
+{{/if}}
+
+<div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-4">
+    <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-4" data-toggle-class="is-collapsed">
         {{ i18n "towns" }}
         {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-footer-chevron c-icon--chevron u-showBelowWide" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />
@@ -44,8 +60,8 @@
     </ul>
 </div>
 
-<div class="g-col g-span3 c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-4">
-    <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-4" data-toggle-class="is-collapsed">
+<div class="g-col c-footer-panel" data-panel-collapsible data-toggle-name="footer-panel-5">
+    <h2 class="c-footer-heading" data-footer-panel-heading data-toggle-target="footer-panel-5" data-toggle-class="is-collapsed">
         {{ i18n "aboutUs" }}
         {{!-- {{> je-svg-sprite cssClass="c-footer-chevron c-icon--chevron u-showBelowWide" spriteUrl=(concat svgSpriteModel.iconsSpritePath "#icons-arrows-chevron") }} --}}
         <img class="c-footer-chevron c-icon--chevron u-showBelowWide" src="{{ miscIconPaths.chevronIconUrl }}" alt="" />

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -269,116 +269,124 @@
         "improveOurWebsite": "Ayúdanos a mejorar la web",
         "sendFeedback": "Enviar opinión",
         "vatInfo": "",
-        "customerService": "Atención al cliente",
+        "customerService": "Servicio al cliente",
         "changeCurrentCountry": "Estás en Just Eat España. Haz clic aquí para cambiar país.",
         "buttonClose": "Cerrar",
         "links": [
             {
-                "url": "https://restaurantes.just-eat.es/",
-                "text": "¿Tienes un restaurante?"
+                "url": "/account/login/",
+                "text": "Inicia Sesión"
             },
             {
-                "url": "/contact",
-                "text": "Quienes somos"
+                "url": "/account/register/",
+                "text": "Regístrate"
             },
             {
-                "url": "https://partner.just-eat.es/",
-                "text": "Mi Restaurante"
+                "url": "/blog/",
+                "text": "Nuestro blog"
             },
             {
-                "url": "/blog",
-                "text": "Blog"
-            },
-            {
-                "url": "/apps",
-                "text": "Mobile apps"
-            },
-            {
-                "url": "/faq",
-                "text": "Ayuda"
+                "url": "/account/info/",
+                "text": "Información De La Cuenta"
             }
         ],
         "cuisines": "Tipos de cocina",
         "cuisineLinks": [
             {
-                "url": "/a-domicilio/cerca-de-mi/pizza",
+                "url": "/a-domicilio/cerca-de-mi/pizza/",
                 "text": "Pizza a domicilio"
             },
             {
-                "url": "/a-domicilio/cerca-de-mi/kebab",
+                "url": "/a-domicilio/cerca-de-mi/kebab/",
                 "text": "Kebab a domicilio"
             },
             {
-                "url": "/a-domicilio/cerca-de-mi/comida-china",
+                "url": "/a-domicilio/cerca-de-mi/comida-china/",
                 "text": "Comida china a domicilio"
             },
             {
-                "url": "/a-domicilio/cerca-de-mi/sushi",
+                "url": "/a-domicilio/cerca-de-mi/sushi/",
                 "text": "Sushi a domicilio"
             },
             {
-                "url": "/a-domicilio/cerca-de-mi/hamburguesas",
+                "url": "/a-domicilio/cerca-de-mi/hamburguesas/",
                 "text": "Hamburguesas a domicilio"
             },
             {
-                "url": "/a-domicilio/cerca-de-mi/tipos-de-comida",
-                "text": "Más comida a domicilio"
+                "url": "/a-domicilio/cerca-de-mi/",
+                "text": "Mas tipos de cocina"
             }
         ],
         "towns": "Ciudades",
         "locationLinks": [
             {
-                "url": "/a-domicilio/madrid",
+                "url": "/a-domicilio/madrid/",
                 "text": "Madrid"
             },
             {
-                "url": "/a-domicilio/barcelona",
+                "url": "/a-domicilio/barcelona/",
                 "text": "Barcelona"
             },
             {
-                "url": "/a-domicilio/valencia",
+                "url": "/a-domicilio/valencia/",
                 "text": "Valencia"
             },
             {
-                "url": "/a-domicilio/zaragoza",
+                "url": "/a-domicilio/zaragoza/",
                 "text": "Zaragoza"
             },
             {
-                "url": "/a-domicilio/a-coruna",
-                "text": "A Coruña"
+                "url": "/a-domicilio/palmas-de-gran-canaria/",
+                "text": "Las Palmas"
             },
             {
-                "url": "/a-domicilio",
+                "url": "/a-domicilio/",
                 "text": "Más ciudades"
             }
         ],
-        "brands": "Brands",
+        "brands": "Las marcas",
         "brandLinks": [],
         "aboutUs": "Sobre nosotros",
         "aboutUsLinks": [
             {
-                "url": "/adomicilio/garantia-de-precio",
+                "url": "https://restaurantes.just-eat.es/",
+                "text": "Registrarse en el restaurante"
+            },
+            {
+                "url": "/info/acerca-de-just-eat/",
+                "text": "Quienes somos"
+            },
+            {
+                "url": "/help/",
+                "text": "Ayuda"
+            },
+            {
+                "url": "/info/garantia-de-precio/",
                 "text": "Garantía de precio"
             },
             {
-                "url": "/privacy-policy",
-                "text": "TyCs"
+                "url": "/info/politica-de-privacidad/",
+                "text": "Política de Privacidad"
             },
             {
-                "url": "/cookiespolicy",
-                "text": "Cookies"
+                "url": "/info/terminos-y-condiciones/",
+                "text": "Términos y Condiciones"
             },
             {
-                "url": "/adomicilio/ofertas-localidades",
-                "text": "Ofertas"
+                "url": "/info/politica-de-cookies/",
+                "text": "Política de Cookies"
             },
             {
-                "url": "/press-info",
-                "text": "Prensa"
+                "url": "/blog/descuento-5e-just-eat/",
+                "text": "5€ de descuento"
             },
             {
-                "url": "/jobs",
-                "text": "Trabaja con nosotros"
+                "url": "/campana/afiliacion",
+                "text": "Programa de Afiliación"
+            },
+            {
+                "url": "https://partner.just-eat.es/",
+                "text": "Gestiona tu restaurante"
             }
         ],
         "downloadOurApps": "Descárgate la app",
@@ -1367,83 +1375,78 @@
         "buttonClose": "Chiudi",
         "links": [
             {
-                "url": "/help",
-                "text": "Aiuto?"
+                "url": "/account/login/",
+                "text": "Accedi"
             },
             {
-                "url": "/account/login",
-                "text": "Accedi",
-                "rel": "nofollow"
-            },
-            {
-                "url": "/account/register",
+                "url": "/account/register/",
                 "text": "Registrati"
             },
             {
-                "url": "/blog",
+                "url": "/blog/",
                 "text": "Blog"
             },
             {
-                "url": "/apps",
-                "text": "App"
+                "url": "/account/info/",
+                "text": "Il mio account"
+            },
+            {
+                "url": "/help/",
+                "text": "Aiuto?"
             }
         ],
         "cuisines": "Cucine",
         "cuisineLinks": [
             {
-                "url": "/domicilio/pizza",
+                "url": "/domicilio/pizza/",
                 "text": "Pizza a domicilio"
             },
             {
-                "url": "/domicilio/cinese",
+                "url": "/domicilio/cines/e",
                 "text": "Cinese a domicilio"
             },
             {
-                "url": "/domicilio/sushi",
+                "url": "/domicilio/sushi/",
                 "text": "Sushi a domicilio"
             },
             {
-                "url": "/domicilio/hamburger",
-                "text": "Hamburger a domicilio"
+                "url": "/domicilio/vicino-a-me/kebab/",
+                "text": "Kebab a domicilio"
             },
             {
-                "url": "/domicilio/tipi-cucina",
+                "url": "/domicilio/tipi-cucina/",
                 "text": "Tutti i tipi di cucine"
             }
         ],
         "towns": "Città",
         "locationLinks": [
             {
-                "url": "/domicilio/palermo",
+                "url": "/domicilio/palermo/",
                 "text": "Palermo"
             },
             {
-                "url": "/domicilio/roma",
+                "url": "/domicilio/roma/",
                 "text": "Roma"
             },
             {
-                "url": "/domicilio/milano",
+                "url": "/domicilio/milano/",
                 "text": "Milano"
             },
             {
-                "url": "/domicilio/napoli",
+                "url": "/domicilio/napoli/",
                 "text": "Napoli"
             },
             {
-                "url": "/domicilio/Torino",
+                "url": "/domicilio/torino/",
                 "text": "Torino"
             },
             {
-                "url": "/domicilio/bologna",
+                "url": "/domicilio/bologna/",
                 "text": "Bologna"
             },
             {
-                "url": "/domicilio/citta",
+                "url": "/domicilio/citta/",
                 "text": "Tutte le città"
-            },
-            {
-                "url": "/domicilio/citta-offerte",
-                "text": "Offerte e Sconti"
             }
         ],
         "brands": "Brands",
@@ -1451,39 +1454,39 @@
         "aboutUs": "Chi siamo",
         "aboutUsLinks": [
             {
-                "url": "/privacy-policy",
+                "url": "/privacy-policy/",
                 "text": "Termini e Condizioni"
             },
             {
-                "url": "/cookiespolicy",
+                "url": "/cookiespolicy/",
                 "text": "Cookie Policy"
             },
             {
-                "url": "/about",
+                "url": "/about/",
                 "text": "Informazioni su Just Eat"
             },
             {
-                "url": "/faq",
+                "url": "/faq/",
                 "text": "Domande frequenti"
             },
             {
-                "url": "/domicilio/miglior-prezzo-garantito",
+                "url": "/domicilio/miglior-prezzo-garantito/",
                 "text": "Miglior Prezzo Garantito"
             },
             {
-                "url": "/jobs",
+                "url": "/jobs/",
                 "text": "Lavora con noi"
             },
             {
-                "url": "https://www.justeat.it/domicilio/driver-partner",
+                "url": "https://www.justeat.it/domicilio/driver-partner/",
                 "text": "Diventa un Rider"
             },
             {
-                "url": "/press-info",
+                "url": "/press-info/",
                 "text": "Area stampa"
             },
             {
-                "url": "/app",
+                "url": "/app/",
                 "text": "Le nostre App"
             }
         ],

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1398,15 +1398,15 @@
         "cuisines": "Cucine",
         "cuisineLinks": [
             {
-                "url": "/domicilio/pizza/",
+                "url": "/domicilio/domicilio/vicino-a-me/pizza/",
                 "text": "Pizza a domicilio"
             },
             {
-                "url": "/domicilio/cines/e",
+                "url": "/domicilio/vicino-a-me/cinese",
                 "text": "Cinese a domicilio"
             },
             {
-                "url": "/domicilio/sushi/",
+                "url": "/domicilio/vicino-a-me/sushi/",
                 "text": "Sushi a domicilio"
             },
             {
@@ -1414,7 +1414,7 @@
                 "text": "Kebab a domicilio"
             },
             {
-                "url": "/domicilio/tipi-cucina/",
+                "url": "/domicilio/vicino-a-me/",
                 "text": "Tutti i tipi di cucine"
             }
         ],

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1684,6 +1684,8 @@
                 "text": "Waterford"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "About us",
         "aboutUsLinks": [
             {

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -98,6 +98,8 @@
                 "text": "Alle byer"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "Om os",
         "aboutUsLinks": [
             {
@@ -350,6 +352,8 @@
                 "text": "Más ciudades"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "Sobre nosotros",
         "aboutUsLinks": [
             {
@@ -612,6 +616,8 @@
                 "text": "View all locations"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "A bit more about us",
         "aboutUsLinks": [
             {
@@ -793,55 +799,67 @@
         "buttonClose": "Close",
         "links": [
             {
-                "url": "/content/",
-                "text": "Get to know us"
-            },
-            {
-                "url": "/content/partner-with-us/",
-                "text": "Work with us"
-            },
-            {
-                "url": "/help",
+                "url": "/content/contact-us/",
                 "text": "Contact us"
+            },
+            {
+                "url": "/account/login/",
+                "text": "Log in"
+            },
+            {
+                "url": "/account/register/",
+                "text": "Sign up"
+            },
+            {
+                "url": "/account/info/",
+                "text": "My account"
+            },
+            {
+                "url": "/blog/",
+                "text": "Menulog blog"
+            },
+            {
+                "url": "/help/",
+                "text": "Help centre"
             }
         ],
         "cuisines": "Cuisines",
         "cuisineLinks": [
             {
-                "url": "/content/browse/burgers",
-                "text": "Burgers"
+                "url": "/browse/burgers",
+                "text": "Burgers Delivery"
             },
             {
                 "url": "/browse/chinese",
-                "text": "Chinese"
+                "text": "Chinese Delivery"
             },
             {
                 "url": "/browse/indian",
-                "text": "Indian"
+                "text": "Indian Delivery"
             },
             {
                 "url": "/content/browse/italian",
-                "text": "Italian"
+                "text": "Italian Delivery"
             },
             {
                 "url": "/browse/japanese",
-                "text": "Japanese"
+                "text": "Japanese Delivery"
             },
             {
                 "url": "/browse/korean",
-                "text": "Korean"
+                "text": "Korean Delivery"
             },
             {
                 "url": "/browse/pizza",
-                "text": "Pizza"
+                "text": "Pizza Delivery"
             },
             {
                 "url": "/browse/thai",
-                "text": "Thai"
+                "text": "Thai Delivery"
             },
             {
                 "url": "/browse/vietnamese",
-                "text": "Vietnamese"
+                "text": "Vietnamese Delivery"
             },
             {
                 "url": "/content/browse",
@@ -888,50 +906,97 @@
             },
             {
                 "url": "/browse",
-                "text": "View all cities"
+                "text": "View all locations"
             }
         ],
-        "aboutUs": "About us",
+        "brands": "Brands",
+        "brandLinks": [
+            {
+                "url": "/content/brands/hungry-jacks/",
+                "text": "Hungry Jack's Delivery"
+            },
+            {
+                "url": "/content/brands/kfc/",
+                "text": "KFC Delivery"
+            },
+            {
+                "url": "/content/brands/crust/",
+                "text": "Crust Delivery"
+            },
+            {
+                "url": "/content/brands/hogs-breath/",
+                "text": "Hog's Breath Delivery"
+            },
+            {
+                "url": "/content/brands/oporto/",
+                "text": "Oporto Delivery"
+            },
+            {
+                "url": "/content/brands/pizza-hut/",
+                "text": "Pizza Hut Delivery"
+            },
+            {
+                "url": "/content/brands/red-rooster/",
+                "text": "Red Rooster Delivery"
+            },
+            {
+                "url": "/content/brands/subway/",
+                "text": "Subway Delivery"
+            },
+            {
+                "url": "/content/brands/zambrero/",
+                "text": "Zambrero Delivery"
+            },
+            {
+                "url": "/browse/",
+                "text": "View all brands"
+            }
+        ],
+        "aboutUs": "A bit more about us",
         "aboutUsLinks": [
             {
                 "url": "/content/",
                 "text": "About Menulog"
             },
             {
-                "url": "/content/our-price-promise",
-                "text": "Our Price Promise"
-            },
-            {
-                "url": "/content/partner-with-us",
-                "text": "Partner with Us"
+                "url": "/content/our-price-promise/",
+                "text": "Price promise"
             },
             {
                 "url": "/content/partner-with-us/",
-                "text": "Menulog Careers"
+                "text": "Partner with us"
             },
             {
-                "url": "/content/corporate-partners",
-                "text": "Corporate Partners"
+                "url": "/content/partner-with-us/",
+                "text": "Menulog careers"
             },
             {
-                "url": "/content/contact-us",
-                "text": "Contact Us"
+                "url": "/content/corporate-partners/",
+                "text": "Corporate partners"
             },
             {
                 "url": "/blog/category/press/",
                 "text": "Media Centre"
             },
             {
-                "url": "/help/",
-                "text": "Help Centre"
+                "url": "/privacy-policy/",
+                "text": "Privacy Policy and Terms of Use"
             },
             {
-                "url": "/blog/",
-                "text": "Menulog Blog"
+                "url": "https://partner.menulog.com.au/",
+                "text": "Partner centre"
             },
             {
-                "url": "/privacy-policy",
-                "text": "Privacy Policy / Terms & Conditions"
+                "url": "https://couriers.menulog.com.au/application/",
+                "text": "Become a courier"
+            },
+            {
+                "url": "https://couriers.menulog.com.au/",
+                "text": "Courier portal"
+            },
+            {
+                "url": "/content/join-menulog",
+                "text": "List your restaurant"
             }
         ],
         "downloadOurApps": "Download our apps",
@@ -1077,20 +1142,28 @@
         "buttonClose": "Close",
         "links": [
             {
-                "url": "/content/get-to-know-us/",
-                "text": "Get to know us"
-            },
-            {
-                "url": "/content/work-with-us/",
-                "text": "Work with us"
-            },
-            {
-                "url": "/help",
+                "url": "/content/contact-us/",
                 "text": "Contact us"
             },
             {
-                "url": "/help",
-                "text": "Help Centre"
+                "url": "/account/login/",
+                "text": "Log in"
+            },
+            {
+                "url": "/account/register/",
+                "text": "Sign up"
+            },
+            {
+                "url": "/account/info/",
+                "text": "My account"
+            },
+            {
+                "url": "/blog/",
+                "text": "Menulog blog"
+            },
+            {
+                "url": "/help/",
+                "text": "Help centre"
             }
         ],
         "cuisines": "Top cuisines",
@@ -1135,16 +1208,26 @@
                 "text": "Dunedin"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "A bit more about us",
         "aboutUsLinks": [
 
             {
-                "url": "/blog",
-                "text": "Menulog Blog"
+                "url": "/about_menulog",
+                "text": "Get to know us"
             },
             {
                 "url": "/privacy-policy#privacy_policy",
                 "text": "Privacy Policy / Terms & Conditions"
+            },
+            {
+                "url": "https://connect.menulog.co.nz/login?client_id=RappsOrigPartnerCentre&response_type=code&redirect_uri=https:%2F%2Fpartner.menulog.co.nz%2Fsignin-jeconnect&state=QaF4ae5nfj7FUpuoevTVCHvmMBxIA1hO_4mDtePNEJOasCly6wdTLaHjTuvS7_If4SwPYZelgwT0ZFYb7CCZvfIIr9X0OVLKiRpdCLYU9zJPuorMgnFjjRlyQNdU8L_5ZvkfGGBtXJx-jNOlh5lU_aqiQ-KgrKthGa83ZbYH8GjV81bwGb7iJ8PRFJPYbwTyys-zclUwNFxXhfdsOpqIWsIlfpQ",
+                "text": "Partner Centre"
+            },
+            {
+                "url": "/join_takeaway_section",
+                "text": "Restaurant sign up"
             }
         ],
         "downloadOurApps": "Download our apps",
@@ -1363,6 +1446,8 @@
                 "text": "Offerte e Sconti"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "Chi siamo",
         "aboutUsLinks": [
             {
@@ -1844,6 +1929,8 @@
                 "text": "Alle byer"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "Om oss",
         "aboutUsLinks": [
             {
@@ -2090,6 +2177,8 @@
                 "text": "View all locations"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "About Us",
         "aboutUsLinks": [
             {
@@ -2360,6 +2449,8 @@
                 "text": "Voir toutes les villes"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "À propos de Just Eat",
         "aboutUsLinks": [
             {
@@ -2623,6 +2714,8 @@
                 "text": "[Ṽîéŵẋẋ åļļẋ ļöçåţîöñšẋẋẋ]"
             }
         ],
+        "brands": "Brands",
+        "brandLinks": [],
         "aboutUs": "[Åẋ ƀîţẋ ɱöŕéẋẋ åƀöûţẋẋ ûšẋ]",
         "aboutUsLinks": [
             {

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1398,7 +1398,7 @@
         "cuisines": "Cucine",
         "cuisineLinks": [
             {
-                "url": "/domicilio/domicilio/vicino-a-me/pizza/",
+                "url": "/domicilio/vicino-a-me/pizza/",
                 "text": "Pizza a domicilio"
             },
             {
@@ -1406,7 +1406,7 @@
                 "text": "Cinese a domicilio"
             },
             {
-                "url": "/domicilio/vicino-a-me/sushi/",
+                "url": "/domicilio/vicino-a-me/sushi-giapponese/",
                 "text": "Sushi a domicilio"
             },
             {
@@ -1454,15 +1454,15 @@
         "aboutUs": "Chi siamo",
         "aboutUsLinks": [
             {
-                "url": "/privacy-policy/",
+                "url": "/informazioni/privacy-policy/",
                 "text": "Termini e Condizioni"
             },
             {
-                "url": "/cookiespolicy/",
+                "url": "/informazioni/politica-dei-cookie/",
                 "text": "Cookie Policy"
             },
             {
-                "url": "/about/",
+                "url": "/informazioni/about-us/",
                 "text": "Informazioni su Just Eat"
             },
             {
@@ -1470,19 +1470,19 @@
                 "text": "Domande frequenti"
             },
             {
-                "url": "/domicilio/miglior-prezzo-garantito/",
+                "url": "/informazioni/miglior-prezzo-garantito/",
                 "text": "Miglior Prezzo Garantito"
             },
             {
-                "url": "/jobs/",
+                "url": "/informazioni/lavora-con-noi/",
                 "text": "Lavora con noi"
             },
             {
-                "url": "https://www.justeat.it/domicilio/driver-partner/",
+                "url": "/informazioni/driver-partner/",
                 "text": "Diventa un Rider"
             },
             {
-                "url": "/press-info/",
+                "url": "/informazioni/media-and-press/",
                 "text": "Area stampa"
             },
             {


### PR DESCRIPTION
1. This PR updates the links in the footer for Australia, New Zealand Spain and Italy - the first wave of new HomeWeb tenants.
2. It introduces a new brands column which shows up for Australia. It is conditionally rendered based on whether any brands have been configured for the tenant.
3. It involves removing a grid css class from the footer columns so that flex display correctly assumes the right widths based on how many are rendered.

**I intend to add system tests to HomeWeb which validate the brand logic, as this repository does not look like it is setup for Handlebars tests, and within the next month we hopefully will phase out this repo - so I don't want to spend ages updating it.**

## UI Review Checks
![FooterUpdate](https://user-images.githubusercontent.com/10741583/56737086-8ad1ba80-6761-11e9-8bbd-27d221ddc507.png)
![phone-brands](https://user-images.githubusercontent.com/10741583/56817713-01dc8100-683e-11e9-9b11-55aa79fa7aee.png)

- [-] This PR has been checked with regard to our brand guidelines
- [-] UI Documentation has been [created|updated]
- [-] JavaScript Tests have been [created|updated]

## Browsers Tested

- [x] Chrome
- [x] Opera
- [x] IE 11
- [x] Firefox
- [x] Mobile Emulator in Chromium

- [View the Browser Support Checklist](https://fozzie.just-eat.com/documentation/general/browser-support)