### PR TITLE
v1.25.0 - Remove careers link for AU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,25 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.25.0
+------------------------------
+*June 19, 2019*
+
+### Removed
+- Careers link for AU
+
+
 v1.24.0
 ------------------------------
-*June 06, 2019*
+*June 6, 2019*
 
 ### Added
 - Added footer links for gift cards
 
+
 v1.23.0
 ------------------------------
-*June 05, 2019*
+*June 5, 2019*
 
 ### Updated
 - Package dependencies.
@@ -34,9 +43,10 @@ v1.21.0
 ### Changed
 - Play store links for Android and Iphone
 
+
 v1.20.0
 ------------------------------
-*May 07, 2019*
+*May 7, 2019*
 
 ### Added
 - Updated footer content for Australia, New Zealand, Italy and Spain

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -983,10 +983,6 @@
                 "text": "Partner with us"
             },
             {
-                "url": "/content/partner-with-us/",
-                "text": "Menulog careers"
-            },
-            {
                 "url": "/content/corporate-partners/",
                 "text": "Corporate partners"
             },


### PR DESCRIPTION
Remove careers link for Australia, the new pages are not yet ready. Once they are, they can be either re-added here or added to the global footer.

## Browsers Tested
- [ ] Chrome