### PR TITLE
v1.25.1 - Update the Diverenta un Rider link in Italy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.25.1
+------------------------------
+*July 03, 2019*
+
+### Changed
+- Update URL for the "Diverenta un Rider" link in Italy
+
+
 v1.25.0
 ------------------------------
 *June 19, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1482,7 +1482,7 @@
                 "text": "Lavora con noi"
             },
             {
-                "url": "/informazioni/driver-partner/",
+                "url": "http://riders.justeat.it/application",
                 "text": "Diventa un Rider"
             },
             {

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -1482,7 +1482,7 @@
                 "text": "Lavora con noi"
             },
             {
-                "url": "http://riders.justeat.it/application",
+                "url": "https://riders.justeat.it/application",
                 "text": "Diventa un Rider"
             },
             {


### PR DESCRIPTION
This is an update in the resource data for the URL associated with the "Diverenta un Rider" link for Italy. No UI changes required.