### PR TITLE
v1.25.4: update footer links for AU Menulog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.25.4
+------------------------------
+*July 29, 2019*
+
+### Changed
+- Update footer URL for the "About Us" section in Australia(Menulog)
+
 v1.25.3
 ------------------------------
 *July 12, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.25.3",
+  "version": "1.25.4",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -987,8 +987,8 @@
               "text": "Corporate Partners"
             },
             {
-              "url": "/blog",
-              "text": "Menulog Blog"
+              "url": "/blog/menulog-news",
+              "text": "Media Centre"
             },
             {
               "url": "/info/privacy-policy",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -922,7 +922,7 @@
             },
             {
                 "url": "/takeaway/",
-                "text": "Browse more locations"
+                "text": "Browse more cities"
             }
         ],
         "brands": "Brands",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -879,7 +879,7 @@
             },
             {
                 "url": "/takeaway/nearme/",
-                "text": "View all cuisines"
+                "text": "Browse more cuisines"
             }
         ],
         "towns": "Locations",
@@ -922,7 +922,7 @@
             },
             {
                 "url": "/takeaway/",
-                "text": "View all locations"
+                "text": "Browse more locations"
             }
         ],
         "brands": "Brands",
@@ -965,50 +965,50 @@
             },
             {
                 "url": "/browse/",
-                "text": "View all brands"
+                "text": "Browse more brands"
             }
         ],
         "aboutUs": "A bit more about us",
         "aboutUsLinks": [
             {
-                "url": "/content/",
-                "text": "About Menulog"
+              "url": "/info/about-us",
+              "text": "About Menulog"
             },
             {
-                "url": "/content/our-price-promise/",
-                "text": "Price promise"
+              "url": "/info/our-price-promise",
+              "text": "Our Price Promise"
             },
             {
-                "url": "/content/partner-with-us/",
-                "text": "Partner with us"
+              "url": "/info/partner-with-us/",
+              "text": "Partner with Us"
             },
             {
-                "url": "/content/corporate-partners/",
-                "text": "Corporate partners"
+              "url": "/info/corporate-partners",
+              "text": "Corporate Partners"
             },
             {
-                "url": "/blog/category/press/",
-                "text": "Media Centre"
+              "url": "/blog",
+              "text": "Menulog Blog"
             },
             {
-                "url": "/privacy-policy/",
-                "text": "Privacy Policy and Terms of Use"
+              "url": "/info/privacy-policy",
+              "text": "Privacy Policy and Terms of Use"
             },
             {
-                "url": "https://partner.menulog.com.au/",
-                "text": "Partner centre"
+              "url": "https://partner.menulog.com.au/",
+              "text": "Partner Centre"
             },
             {
-                "url": "https://couriers.menulog.com.au/application/",
-                "text": "Become a courier"
+              "url": "https://couriers.menulog.com.au/application",
+              "text": "Become a Courier"
             },
             {
-                "url": "https://couriers.menulog.com.au/",
-                "text": "Courier portal"
+              "url": "https://couriers.menulog.com.au/login",
+              "text": "Courier Portal"
             },
             {
-                "url": "/content/join-menulog",
-                "text": "List your restaurant"
+              "url": "/info/join-menulog",
+              "text": "List Your Restaurant"
             }
         ],
         "downloadOurApps": "Download our apps",


### PR DESCRIPTION
## [MCC-1449 Update the "About Us" URLs on the footer](https://jira.just-eat.net/browse/MCC-1449)

Update footer links/texts in **footer.json** file. No UI change involved.
<img width="1262" alt="Screen Shot 2019-07-29 at 3 43 53 pm" src="https://user-images.githubusercontent.com/28050187/62024447-536b2200-b218-11e9-83c8-43f81816433d.png">

## Browsers Tested

- [x] Chrome
- [x] Safari
- [x] IE 11
- [x] Firefox