### PR TITLE
v1.25.5: Fix Danish app download links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.25.5
+------------------------------
+*August 23, 2019*
+
+### Fixed
+- Fix broken app download URLs for Denmark
+
+### Removed
+- Microsoft app download link for Denmark
+
 v1.25.4
 ------------------------------
 *July 29, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.25.4",
+  "version": "1.25.5",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/footer.json
+++ b/src/templates/resources/footer.json
@@ -134,22 +134,16 @@
         "downloadOurApps": "Download vores app",
         "appStoreIcons": [
             {
-                "url": "https://170720.measurementapi.com/serve?action=click&publisher_id=170720&site_id=109400&my_campaign=website-app-page",
+                "url": "https://app.adjust.com/lgmmz6?utm_medium=internal&campaign=homepage",
                 "key": "ios",
                 "iconSrc": "iosIconSrc",
                 "altText": "Hent i App Store"
             },
             {
-                "url": "https://170720.measurementapi.com/serve?action=click&publisher_id=170720&site_id=108390&my_campaign=website-app-page",
+                "url": "https://app.adjust.com/5sd9oz?utm_medium=internal&campaign=homepage",
                 "key": "android",
                 "iconSrc": "androidIconSrc",
                 "altText": "Hent i Google Play"
-            },
-            {
-                "url": "https://www.microsoft.com/store/apps/9nblggh4vk8q",
-                "key": "microsoft",
-                "iconSrc": "microsoftIconSrc",
-                "altText": "Hent i Windows Store"
             }
         ],
         "followUs": "Følg os",


### PR DESCRIPTION
  * Fix URLs for Android and iOS apps (they didn't work at all).
  * Remove Microsoft app (it is no longer available).
