### PR TITLE
v1.30.0 - Updating grey aliases from fozzie-colour-palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.30.0
+------------------------------
+*July 22, 2020*
+
+### Changed
+- Updated `fozzie` and `fozzie-colour-palette` to pull in grey alias updates.
+
+
 v1.29.0
 ------------------------------
 *July 20, 2020*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@justeat/f-utils": "0.2.0",
-    "@justeat/fozzie": "3.0.0-beta.7",
-    "@justeat/fozzie-colour-palette": "3.0.0-beta.3",
+    "@justeat/fozzie": "3.0.0-beta.8",
+    "@justeat/fozzie-colour-palette": "3.0.0-beta.4",
     "include-media": "1.4.9",
     "lite-ready": "1.0.4",
     "lodash.debounce": "4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -923,20 +923,20 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-0.3.0.tgz#1f18ba13ad7061e21c2112387234a77ba45fb5d3"
   integrity sha512-hqRiGA2lP++Z1oqawsv1V2Duf3YShaAbJ3S5JEPTpTMP5RjH36Xpc8nRbIVFBmwnZCu7L9iF7AebYTUX8XhiZA==
 
-"@justeat/fozzie-colour-palette@3.0.0-beta.3":
-  version "3.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.3.tgz#2778982a3982099d2d077eb49fd1fc75b5f449cf"
-  integrity sha512-DaP6Qs+5LTed44wNzLVitKmu6O4MfMFIKZXLtpq9wcndU30oToOI2YwYIQ1ULguCAHCPwNg5pc9bR7uQqkAtTw==
+"@justeat/fozzie-colour-palette@3.0.0-beta.4":
+  version "3.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie-colour-palette/-/fozzie-colour-palette-3.0.0-beta.4.tgz#cd36b52d9ae346f5101d3a5914bc91d086177461"
+  integrity sha512-LOcUh6H66CzNAakHTvy9QDRwzLGGBP+evZwOJDj2oV6lbYhWLN2Sb7ldnooFdgSBNwwuTSOm8tW0o/8KLMqnsQ==
 
-"@justeat/fozzie@3.0.0-beta.7":
-  version "3.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-3.0.0-beta.7.tgz#eb113ef2f5fff5319db9371cfaa259700aa333c4"
-  integrity sha512-osmZ9MnUNJ+aCvbWj+B2Td6GqrRFWJLW0LmdvY7WSGYnAXpeTx2sR3vu95RIMFWpruHY8ZnAGavU+NhIm4MCTQ==
+"@justeat/fozzie@3.0.0-beta.8":
+  version "3.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-3.0.0-beta.8.tgz#b3bc41145f4fa54a09ecedf54db08b61e0c46066"
+  integrity sha512-5Y/Kg668DWK/1ilb6WddOQ0nwfWc57m8MqpHAAxIsaQQbTO5ANRcZsmBWmBAt+rEKzG2sUmP5BaqZe/kwc1ENA==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"
     "@justeat/f-utils" "0.3.0"
-    "@justeat/fozzie-colour-palette" "3.0.0-beta.3"
+    "@justeat/fozzie-colour-palette" "3.0.0-beta.4"
     fontfaceobserver "2.1.0"
     include-media "1.4.9"
     kickoff-grid.css "1.2.0"


### PR DESCRIPTION
### Changed
- Updated `fozzie` and `fozzie-colour-palette` to pull in grey alias updates.