### PR TITLE
v1.31.0 - Use latest greys to match Vue footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ v1.31.0
 
 ### Changed
 - Use darker greys for background, border and icon colours.
-- Fix small visual issue with the border below the lists.
+
+### Fixed
+- Small visual issue with the border below the lists.
 
 
 v1.30.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.31.0
 
 ### Changed
 - Use darker greys for background, border and icon colours.
+- Fix small visual issue with the border below the lists.
 
 
 v1.30.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.31.0
+------------------------------
+*July 24, 2020*
+
+### Changed
+- Use darker greys for background, border and icon colours.
+
+
 v1.30.0
 ------------------------------
 *July 22, 2020*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -95,9 +95,13 @@ $footer-socialIconColor : $grey--darkest !default;
 
 
     .c-footer-panel {
+        border-bottom: none;
+
+        @include media('<mid') {
+            border-bottom: 1px solid $footer-borderColor;
+        }
 
         @include media('<wide') {
-            border-bottom: 1px solid $footer-borderColor;
             cursor: pointer;
 
             .c-footer-chevron {
@@ -113,10 +117,6 @@ $footer-socialIconColor : $grey--darkest !default;
                     display: none;
                 }
             }
-        }
-
-        &:last-of-type {
-            border-bottom: none;
         }
 
         .c-footer-heading {

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -29,12 +29,12 @@
 /**
  * Component Variables
  */
-$footer-bgColor         : $grey--lighter !default;
-$footer-bgLight         : $grey--offWhite !default;
+$footer-bgColor         : $grey--light !default;
+$footer-bgLight         : $grey--lighter !default;
 $footer-textColor       : $color-text !default;
-$footer-borderColor     : $color-border--interactive !default;
-$footer-chevronColor    : $grey--dark !default;
-$footer-socialIconColor : $grey--dark !default;
+$footer-borderColor     : $color-border !default;
+$footer-chevronColor    : $grey--darkest !default;
+$footer-socialIconColor : $grey--darkest !default;
 
 
 /**

--- a/src/scss/partials/_countrySelector.scss
+++ b/src/scss/partials/_countrySelector.scss
@@ -10,9 +10,8 @@
  * Component Variables
  */
 $countrySelector-textColor      : $color-text !default;
-$countrySelector-chevronColor   : $grey--dark !default;
-$countrySelector-crossColor     : $blue !default;
-$countrySelector-bgColor        : $grey--offWhite !default;
+$countrySelector-iconColor      : $grey--darkest !default;
+$countrySelector-bgColor        : $grey--lighter !default;
 $countrySelector-borderColor    : $color-border !default;
 $countrySelector-boxShadow      : 0 2px 28px rgba(51, 51, 51, 0.08) !default;
 
@@ -74,12 +73,12 @@ $countrySelector-boxShadow      : 0 2px 28px rgba(51, 51, 51, 0.08) !default;
         height: 6px;
         margin-left: spacing();
         width: 14px;
-        fill: $countrySelector-chevronColor;
+        fill: $countrySelector-iconColor;
     }
 
     .c-countrySelector-cross {
         align-self: center;
-        fill: $countrySelector-crossColor;
+        fill: $countrySelector-iconColor;
         height: 24px;
         margin-left: auto;
         margin-right: spacing();


### PR DESCRIPTION
### Changed
- Use darker greys for background, border and icon colours.

### Fixed
- Small visual issue with the border below the lists.

---

![localhost_9394_order-history](https://user-images.githubusercontent.com/26894168/88411324-a1851800-cdcf-11ea-9d1a-14e143c2d3ff.png)

---

![localhost_9394_order-history (1)](https://user-images.githubusercontent.com/26894168/88411344-a9dd5300-cdcf-11ea-92ca-f5457649d231.png)

---

## Browsers Tested
- [x] Chrome
- [ ] Safari
- [ ] IE 11
- [ ] Firefox
- [ ] Mobile (i.e. iPhone/Android - please list device)