### PR TITLE
f-footer-1.41.1 - Republish with correct tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.41.1
+------------------------------
+*August 10, 2021*
+
+### Changed
+- Need to republish with the correct tag
+
+
 v1.41.0
 ------------------------------
 *August 9, 2021*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-footer",
   "description": "Fozzie footer – Footer Component for Just Eat projects",
-  "version": "1.41.0",
+  "version": "1.41.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",


### PR DESCRIPTION
SEO updates to brand links.

Previous publish missed the "legacy" tag